### PR TITLE
fix: address Windows installer regressions after v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ a card-based UI, or query from the command line.
 - 🏷️ **Smart tags** — `#todo`, `#urgent`, `#important`, `#idea` with emoji prefixes
 - 🔤 **Autocomplete** — type `#` and pick a tag from the popup
 - ✨ **Guided onboarding** — first-run wizard for new users plus lightweight installed-build welcome/upgrade flow
-- ⚙️ **Settings window** — hotkey, theme, window size, startup, and custom tag management from the UI
+- ⚙️ **Settings window** — theme, window size, startup, and custom tag management from the UI, with hotkey shown for reference
 - 🎨 **Themes** — 5 built-in color schemes (tokyo-night, light, dracula, gruvbox, mono)
 - 🗂️ **Browse window** — card view with live search, tag filtering, and mark-done
 - 💻 **CLI commands** — `recent`, `search`, `tags`, `add`, `edit`, `delete`, `export`, `stats`, and `config`
@@ -61,7 +61,7 @@ On Windows you can now choose between:
 > **Tip:** The `.zip` / `.tar.gz` files are UI onedir bundles (a folder with all files).
 > They start slightly faster but aren't a single portable file.
 
-> **Uninstall note (Windows installer):** uninstall removes the installed app, installer-managed `PATH` and startup entries, shortcuts, and uninstall entry. If CogStash is still running, the installer prompts you to close it first. Your personal notes, config, and log files are kept by default.
+> **Uninstall note (Windows installer):** uninstall removes the installed app, installer-managed `PATH` entry, the CogStash startup script if present, shortcuts, and uninstall entry. If CogStash is still running, the installer prompts you to close it first. Your personal notes, config, and log files are kept by default.
 >
 > **Installed-launch note:** new users still get the full first-run wizard. The installed Windows app shows a lightweight installer welcome for installed-app upgrades and for a first installed launch over an existing config from a portable or source run.
 
@@ -127,7 +127,7 @@ Multi-line notes use 2-space indented continuation lines.
 New users see the first-run wizard on their first launch. After that, use the tray icon to open:
 
 - **Browse Notes** for searching, filtering, editing, and marking notes done
-- **Settings** for hotkey, theme, window size, startup, and tag preferences
+- **Settings** for theme, window size, startup, and tag preferences, with the current hotkey shown for reference
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,16 +52,14 @@ Grab the latest release from the [**Releases page**](https://github.com/abdul219
 
 On Windows you can now choose between:
 
-- `CogStash-vX.Y.Z-setup.exe` — installs `CogStash.exe` and `CogStash-CLI.exe` to `%LocalAppData%\Programs\CogStash`, adds an Apps & Features entry, creates Start Menu/Desktop shortcuts only for the UI app, and can optionally enable launch at sign-in during setup.
+- `CogStash-vX.Y.Z-setup.exe` — installs `CogStash.exe` and `CogStash-CLI.exe` to `%LocalAppData%\Programs\CogStash`, adds an Apps & Features entry, creates Start Menu/Desktop shortcuts only for the UI app, and can optionally enable launch at sign-in plus add the installed CLI directory to `PATH` during setup.
 - `CogStash-vX.Y.Z-windows.exe` — portable onefile executable; download and run without installing.
 - `CogStash-CLI-vX.Y.Z-windows.exe` — portable CLI executable for shell-only usage.
 
 > **Tip:** The `.zip` / `.tar.gz` files are UI onedir bundles (a folder with all files).
 > They start slightly faster but aren't a single portable file.
 
-> **Uninstall note (Windows installer):** uninstall removes the installed app, shortcuts,
-> uninstall entry, and installer-managed startup entry, but keeps your personal notes,
-> config, and log files by default.
+> **Uninstall note (Windows installer):** uninstall removes the installed app, installer-managed `PATH` and startup entries, shortcuts, and uninstall entry. If CogStash is still running, the installer prompts you to close it first. Your personal notes, config, and log files are kept by default.
 
 ### Option 2: From source (with uv)
 
@@ -91,7 +89,8 @@ uv sync
 
 # If using the Windows installer:
 # Launch CogStash from the Start Menu after setup
-# Or run %LocalAppData%\Programs\CogStash\CogStash-CLI.exe from a shell
+# Or, if you selected the PATH option during setup, run: CogStash-CLI.exe --help
+# Otherwise run %LocalAppData%\Programs\CogStash\CogStash-CLI.exe from a shell
 
 # If installed from source with uv:
 uv run cogstash

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ On Windows you can now choose between:
 
 > **Uninstall note (Windows installer):** uninstall removes the installed app, installer-managed `PATH` and startup entries, shortcuts, and uninstall entry. If CogStash is still running, the installer prompts you to close it first. Your personal notes, config, and log files are kept by default.
 >
-> **Installed-launch note:** new users still get the full first-run wizard. If you already have a CogStash config from a portable or source run, the installed Windows app shows a lightweight installer welcome instead of restarting full onboarding.
+> **Installed-launch note:** new users still get the full first-run wizard. The installed Windows app shows a lightweight installer welcome for installed-app upgrades and for a first installed launch over an existing config from a portable or source run.
 
 ### Option 2: From source (with uv)
 
@@ -206,7 +206,7 @@ Example output:
 
 ### `cogstash add`
 
-Add a note directly from the shell.
+Add a note directly from the shell. If you omit the note text, pipe it through stdin.
 
 ```bash
 cogstash add "Ship the installer follow-up" # direct text
@@ -233,7 +233,7 @@ cogstash delete --search "installer" --yes
 
 ### `cogstash export`
 
-Export all notes to JSON, CSV, or Markdown.
+Export all notes to JSON, CSV, or Markdown. Without `--output`, CogStash writes an auto-named export file in the current working directory.
 
 ```bash
 cogstash export --format json
@@ -322,16 +322,20 @@ Example config:
 {
   "hotkey": "<ctrl>+<shift>+<space>",
   "theme": "dracula",
-  "window_size": "wide",
-  "launch_at_startup": true
+  "window_size": "wide"
 }
 ```
 
 Only include the keys you want to override — missing keys use defaults.
 
-> **Note:** `cogstash config get|set` supports `hotkey`, `theme`, `window_size`,
-> `output_file`, `log_file`, and `tags`. The installer/onboarding keys are
-> maintained by the app and installer.
+> **Note:** `cogstash config get` supports `hotkey`, `theme`, `window_size`,
+> `output_file`, `log_file`, and `tags`. `cogstash config set` supports
+> `hotkey`, `theme`, `window_size`, `output_file`, and `log_file`. The
+> installer/onboarding keys are maintained by the app and installer.
+>
+> On Windows, launch-at-startup is managed by the installer/UI startup entry as
+> well as config state, so changing JSON alone is not the recommended way to
+> control it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ a card-based UI, or query from the command line.
 - ⌨️ **Global hotkey** — capture thoughts from any app without switching windows
 - 🏷️ **Smart tags** — `#todo`, `#urgent`, `#important`, `#idea` with emoji prefixes
 - 🔤 **Autocomplete** — type `#` and pick a tag from the popup
+- ✨ **Guided onboarding** — first-run wizard for new users plus lightweight installed-build welcome/upgrade flow
+- ⚙️ **Settings window** — hotkey, theme, window size, startup, and custom tag management from the UI
 - 🎨 **Themes** — 5 built-in color schemes (tokyo-night, light, dracula, gruvbox, mono)
 - 🗂️ **Browse window** — card view with live search, tag filtering, and mark-done
-- 💻 **CLI commands** — `recent`, `search`, `tags` with ANSI-colored output
+- 💻 **CLI commands** — `recent`, `search`, `tags`, `add`, `edit`, `delete`, `export`, `stats`, and `config`
 - 🖥️ **System tray** — runs quietly in the background with a tray icon menu
 - 🌍 **Cross-platform** — Windows, macOS, and Linux
 
@@ -60,6 +62,8 @@ On Windows you can now choose between:
 > They start slightly faster but aren't a single portable file.
 
 > **Uninstall note (Windows installer):** uninstall removes the installed app, installer-managed `PATH` and startup entries, shortcuts, and uninstall entry. If CogStash is still running, the installer prompts you to close it first. Your personal notes, config, and log files are kept by default.
+>
+> **Installed-launch note:** new users still get the full first-run wizard. If you already have a CogStash config from a portable or source run, the installed Windows app shows a lightweight installer welcome instead of restarting full onboarding.
 
 ### Option 2: From source (with uv)
 
@@ -94,6 +98,9 @@ uv sync
 
 # If installed from source with uv:
 uv run cogstash
+
+# CLI dispatch also works through the package module:
+python -m cogstash --help
 ```
 
 CogStash starts in the system tray. Press the hotkey to capture a note:
@@ -117,6 +124,11 @@ Notes are written to `~/cogstash.md` in this format:
 
 Multi-line notes use 2-space indented continuation lines.
 
+New users see the first-run wizard on their first launch. After that, use the tray icon to open:
+
+- **Browse Notes** for searching, filtering, editing, and marking notes done
+- **Settings** for hotkey, theme, window size, startup, and tag preferences
+
 ---
 
 ## Smart Tags
@@ -139,6 +151,20 @@ Tags can appear anywhere in the note text. Multiple tags per note are supported.
 
 CogStash includes a command-line interface for querying notes without opening
 the GUI. Release builds ship it as `CogStash-CLI` alongside the UI app.
+Examples below use `cogstash`; when using packaged binaries, replace that with
+`CogStash-CLI.exe` on Windows or the platform-specific CLI binary from the release.
+
+| Command | Purpose |
+|---------|---------|
+| `recent` | Show recent notes |
+| `search` | Full-text search |
+| `tags` | List tags with counts |
+| `add` | Add a note from arguments or piped stdin |
+| `edit` | Edit a note by number or `--search` |
+| `delete` | Delete a note by number or `--search` |
+| `export` | Export all notes as JSON, CSV, or Markdown |
+| `stats` | Show note and tag statistics |
+| `config` | Launch the config wizard or get/set supported config keys |
 
 ### `cogstash recent`
 
@@ -177,6 +203,61 @@ Example output:
 
 > **Note:** Output is ANSI-colored when writing to a terminal. Colors are
 > automatically disabled when piping to a file or another command.
+
+### `cogstash add`
+
+Add a note directly from the shell.
+
+```bash
+cogstash add "Ship the installer follow-up" # direct text
+echo "Follow up with portable users" | cogstash add
+```
+
+### `cogstash edit`
+
+Edit a note by note number, or resolve it from a search query.
+
+```bash
+cogstash edit 42 "Updated note text"
+cogstash edit --search "installer" "Updated note text"
+```
+
+### `cogstash delete`
+
+Delete a note by note number or search query.
+
+```bash
+cogstash delete 42
+cogstash delete --search "installer" --yes
+```
+
+### `cogstash export`
+
+Export all notes to JSON, CSV, or Markdown.
+
+```bash
+cogstash export --format json
+cogstash export --format csv --output notes.csv
+cogstash export --format md --output notes.md
+```
+
+### `cogstash stats`
+
+Show totals, streaks, tag counts, and related note statistics.
+
+```bash
+cogstash stats
+```
+
+### `cogstash config`
+
+Launch the interactive config wizard, or read/write individual supported keys.
+
+```bash
+cogstash config
+cogstash config get theme
+cogstash config set window_size wide
+```
 
 ---
 
@@ -231,6 +312,9 @@ automatically on first run with default values.
 | `log_file` | `~/cogstash.log` | Path to the log file |
 | `theme` | `tokyo-night` | Color theme |
 | `window_size` | `default` | Capture window size preset |
+| `launch_at_startup` | `false` | UI-managed Windows startup preference |
+| `last_seen_version` | `""` | Internal UI state for first-run / What's New flow |
+| `last_seen_installer_version` | `""` | Internal installer-onboarding state |
 
 Example config:
 
@@ -238,11 +322,16 @@ Example config:
 {
   "hotkey": "<ctrl>+<shift>+<space>",
   "theme": "dracula",
-  "window_size": "wide"
+  "window_size": "wide",
+  "launch_at_startup": true
 }
 ```
 
 Only include the keys you want to override — missing keys use defaults.
+
+> **Note:** `cogstash config get|set` supports `hotkey`, `theme`, `window_size`,
+> `output_file`, `log_file`, and `tags`. The installer/onboarding keys are
+> maintained by the app and installer.
 
 ---
 

--- a/installer/windows/CogStash.iss
+++ b/installer/windows/CogStash.iss
@@ -66,6 +66,7 @@ Filename: "{app}\CogStash.exe"; Description: "Launch CogStash"; Flags: nowait po
 
 [UninstallDelete]
 Type: files; Name: "{userstartup}\CogStash.bat"
+Type: files; Name: "{app}\.cogstash-installed"
 
 [Code]
 const
@@ -145,6 +146,8 @@ end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
+  if CurStep = ssPostInstall then
+    SaveStringToFile(ExpandConstant('{app}\.cogstash-installed'), 'installed', False);
   if (CurStep = ssPostInstall) and WizardIsTaskSelected('startup') then
     SaveStringToFile(ExpandConstant('{userstartup}\CogStash.bat'), StartupBatchContents(), False);
   if (CurStep = ssPostInstall) and WizardIsTaskSelected('addtopath') then

--- a/installer/windows/CogStash.iss
+++ b/installer/windows/CogStash.iss
@@ -145,8 +145,6 @@ end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
-  { installer-state: The startup script is the source of truth for launch_at_startup.
-    CogStash reads startup_script_exists() when Settings opens to sync config.launch_at_startup. }
   if (CurStep = ssPostInstall) and WizardIsTaskSelected('startup') then
     SaveStringToFile(ExpandConstant('{userstartup}\CogStash.bat'), StartupBatchContents(), False);
   if (CurStep = ssPostInstall) and WizardIsTaskSelected('addtopath') then

--- a/installer/windows/CogStash.iss
+++ b/installer/windows/CogStash.iss
@@ -145,6 +145,8 @@ end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
+  { installer-state: The startup script is the source of truth for launch_at_startup.
+    CogStash reads startup_script_exists() when Settings opens to sync config.launch_at_startup. }
   if (CurStep = ssPostInstall) and WizardIsTaskSelected('startup') then
     SaveStringToFile(ExpandConstant('{userstartup}\CogStash.bat'), StartupBatchContents(), False);
   if (CurStep = ssPostInstall) and WizardIsTaskSelected('addtopath') then

--- a/installer/windows/CogStash.iss
+++ b/installer/windows/CogStash.iss
@@ -94,6 +94,40 @@ begin
   end;
 end;
 
+{ Returns PathStr with every exact (case-insensitive) semicolon-delimited
+  segment equal to Segment removed.  All other segments are preserved unchanged. }
+function RemoveExactPathSegment(const PathStr, Segment: String): String;
+var
+  Remaining, Part, NewPath, Sep: String;
+  SemiPos: Integer;
+  SegLower: String;
+begin
+  SegLower := LowerCase(Segment);
+  Remaining := PathStr;
+  NewPath := '';
+  Sep := '';
+  while Remaining <> '' do
+  begin
+    SemiPos := Pos(';', Remaining);
+    if SemiPos > 0 then
+    begin
+      Part := Copy(Remaining, 1, SemiPos - 1);
+      Remaining := Copy(Remaining, SemiPos + 1, Length(Remaining));
+    end
+    else
+    begin
+      Part := Remaining;
+      Remaining := '';
+    end;
+    if LowerCase(Part) <> SegLower then
+    begin
+      NewPath := NewPath + Sep + Part;
+      Sep := ';';
+    end;
+  end;
+  Result := NewPath;
+end;
+
 procedure RemoveInstallerOwnedPath();
 var
   OwnedPath, CurrentPath, NewPath: String;
@@ -102,11 +136,7 @@ begin
     Exit;
   if RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', CurrentPath) then
   begin
-    NewPath := StringReplace(CurrentPath, ';' + OwnedPath, '', [rfIgnoreCase]);
-    if NewPath = CurrentPath then
-      NewPath := StringReplace(CurrentPath, OwnedPath + ';', '', [rfIgnoreCase]);
-    if NewPath = CurrentPath then
-      NewPath := StringReplace(CurrentPath, OwnedPath, '', [rfIgnoreCase]);
+    NewPath := RemoveExactPathSegment(CurrentPath, OwnedPath);
     if NewPath <> CurrentPath then
       RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', NewPath);
   end;

--- a/installer/windows/CogStash.iss
+++ b/installer/windows/CogStash.iss
@@ -41,6 +41,8 @@ Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
 UninstallDisplayIcon={app}\{#AppExeName}
+ChangesEnvironment=yes
+CloseApplications=yes
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -48,6 +50,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 [Tasks]
 Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Additional shortcuts:"
 Name: "startup"; Description: "Launch CogStash when I sign in"; GroupDescription: "Additional tasks:"
+Name: "addtopath"; Description: "Add CogStash CLI to PATH"; GroupDescription: "Additional tasks:"
 
 [Files]
 Source: "{#SourceDir}\{#AppExeName}"; DestDir: "{app}"; Flags: ignoreversion
@@ -65,15 +68,61 @@ Filename: "{app}\CogStash.exe"; Description: "Launch CogStash"; Flags: nowait po
 Type: files; Name: "{userstartup}\CogStash.bat"
 
 [Code]
+const
+  PathOwnershipKey = 'Software\CogStash\Installer';
+  PathOwnershipValue = 'ManagedPath';
+
 function StartupBatchContents(): String;
 begin
   Result := '@echo off' + #13#10 + 'start "" "' + ExpandConstant('{app}\CogStash.exe') + '"' + #13#10;
 end;
 
+procedure AddAppToUserPath();
+var
+  OldPath, AppDir: String;
+begin
+  AppDir := ExpandConstant('{app}');
+  if not RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', OldPath) then
+    OldPath := '';
+  if Pos(LowerCase(AppDir + ';'), LowerCase(OldPath + ';')) = 0 then
+  begin
+    if OldPath = '' then
+      RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', AppDir)
+    else
+      RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', OldPath + ';' + AppDir);
+    RegWriteStringValue(HKEY_CURRENT_USER, PathOwnershipKey, PathOwnershipValue, AppDir);
+  end;
+end;
+
+procedure RemoveInstallerOwnedPath();
+var
+  OwnedPath, CurrentPath, NewPath: String;
+begin
+  if not RegQueryStringValue(HKEY_CURRENT_USER, PathOwnershipKey, PathOwnershipValue, OwnedPath) then
+    Exit;
+  if RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', CurrentPath) then
+  begin
+    NewPath := StringReplace(CurrentPath, ';' + OwnedPath, '', [rfIgnoreCase]);
+    if NewPath = CurrentPath then
+      NewPath := StringReplace(CurrentPath, OwnedPath + ';', '', [rfIgnoreCase]);
+    if NewPath = CurrentPath then
+      NewPath := StringReplace(CurrentPath, OwnedPath, '', [rfIgnoreCase]);
+    if NewPath <> CurrentPath then
+      RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', NewPath);
+  end;
+  RegDeleteValue(HKEY_CURRENT_USER, PathOwnershipKey, PathOwnershipValue);
+end;
+
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
   if (CurStep = ssPostInstall) and WizardIsTaskSelected('startup') then
-  begin
     SaveStringToFile(ExpandConstant('{userstartup}\CogStash.bat'), StartupBatchContents(), False);
-  end;
+  if (CurStep = ssPostInstall) and WizardIsTaskSelected('addtopath') then
+    AddAppToUserPath();
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep = usPostUninstall then
+    RemoveInstallerOwnedPath();
 end;

--- a/src/cogstash/core/config.py
+++ b/src/cogstash/core/config.py
@@ -28,6 +28,7 @@ class CogStashConfig:
     tags: dict[str, dict[str, str]] | None = None
     launch_at_startup: bool = False
     last_seen_version: str = ""
+    last_seen_installer_version: str = ""
 
     def __post_init__(self) -> None:
         if self.output_file is None:
@@ -51,6 +52,7 @@ def load_config(config_path: Path) -> CogStashConfig:
         "window_size": _DEFAULT_WINDOW_SIZE,
         "launch_at_startup": False,
         "last_seen_version": "",
+        "last_seen_installer_version": "",
     }
 
     if not config_path.exists():
@@ -104,6 +106,7 @@ def load_config(config_path: Path) -> CogStashConfig:
         tags=valid_tags if valid_tags else None,
         launch_at_startup=bool(merged.get("launch_at_startup", False)),
         last_seen_version=str(merged.get("last_seen_version", "")),
+        last_seen_installer_version=str(merged.get("last_seen_installer_version", "")),
     )
 
 
@@ -117,6 +120,7 @@ def save_config(config: CogStashConfig, config_path: Path) -> None:
         "window_size": config.window_size,
         "launch_at_startup": config.launch_at_startup,
         "last_seen_version": config.last_seen_version,
+        "last_seen_installer_version": config.last_seen_installer_version,
     }
     if config.tags:
         data["tags"] = config.tags

--- a/src/cogstash/ui/app.py
+++ b/src/cogstash/ui/app.py
@@ -535,7 +535,14 @@ def main():
         config = load_config(config_path)
     else:
         from cogstash import __version__
-        if config.last_seen_version != __version__:
+        from cogstash.ui.install_state import should_show_installer_welcome
+
+        if should_show_installer_welcome(config, __version__):
+            from cogstash.ui.settings import InstallerWelcomeDialog
+            InstallerWelcomeDialog(root, config, config_path, __version__)
+            config.last_seen_version = __version__
+            save_config(config, config_path)
+        elif config.last_seen_version != __version__:
             from cogstash.ui.settings import WhatsNewDialog
             WhatsNewDialog(root, config, config_path, __version__)
             config.last_seen_version = __version__

--- a/src/cogstash/ui/app.py
+++ b/src/cogstash/ui/app.py
@@ -541,6 +541,7 @@ def main():
             from cogstash.ui.settings import InstallerWelcomeDialog
             InstallerWelcomeDialog(root, config, config_path, __version__)
             config.last_seen_version = __version__
+            config.last_seen_installer_version = __version__
             save_config(config, config_path)
         elif config.last_seen_version != __version__:
             from cogstash.ui.settings import WhatsNewDialog

--- a/src/cogstash/ui/install_state.py
+++ b/src/cogstash/ui/install_state.py
@@ -7,13 +7,21 @@ keeps startup-script state accessible without polluting app.py or settings.py.
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 from cogstash.core.config import CogStashConfig
+
+INSTALL_MARKER_NAME = ".cogstash-installed"
+
+
+def _install_marker_path() -> Path:
+    """Return the installer marker path next to the running executable."""
+    return Path(sys.executable).resolve().parent / INSTALL_MARKER_NAME
 
 
 def is_installed_windows_run() -> bool:
     """Return True when running as a frozen (PyInstaller) Windows installed build."""
-    return sys.platform == "win32" and bool(getattr(sys, "frozen", False))
+    return sys.platform == "win32" and bool(getattr(sys, "frozen", False)) and _install_marker_path().exists()
 
 
 def should_show_installer_welcome(config: CogStashConfig, version: str) -> bool:

--- a/src/cogstash/ui/install_state.py
+++ b/src/cogstash/ui/install_state.py
@@ -23,14 +23,15 @@ def should_show_installer_welcome(config: CogStashConfig, version: str) -> bool:
     - Running as the installed Windows app (frozen exe).
     - An existing config exists, i.e. ``last_seen_version`` is non-empty
       (new users with no config see the full first-run wizard instead).
-    - The recorded version differs from *version* (an upgrade or fresh install
-      over an existing config from a previous installation or portable run).
+    - The installer-specific recorded version differs from *version* (covers
+      both upgrades and a first installed launch over an existing config from
+      a previous portable/source run).
     """
     if not is_installed_windows_run():
         return False
     if config.last_seen_version == "":
         return False
-    return config.last_seen_version != version
+    return config.last_seen_installer_version != version
 
 
 def startup_script_exists() -> bool:

--- a/src/cogstash/ui/install_state.py
+++ b/src/cogstash/ui/install_state.py
@@ -6,6 +6,7 @@ keeps startup-script state accessible without polluting app.py or settings.py.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -17,6 +18,12 @@ INSTALL_MARKER_NAME = ".cogstash-installed"
 def _install_marker_path() -> Path:
     """Return the installer marker path next to the running executable."""
     return Path(sys.executable).resolve().parent / INSTALL_MARKER_NAME
+
+
+def get_startup_shortcut_path() -> Path:
+    """Return the Windows startup script path used by CogStash."""
+    startup_dir = Path(os.environ.get("APPDATA", "")) / "Microsoft" / "Windows" / "Start Menu" / "Programs" / "Startup"
+    return startup_dir / "CogStash.bat"
 
 
 def is_installed_windows_run() -> bool:
@@ -46,12 +53,11 @@ def startup_script_exists() -> bool:
     """Return True if the installer-managed startup batch script is present on disk."""
     if sys.platform != "win32":
         return False
-    from cogstash.ui.settings import get_startup_shortcut_path  # lazy — avoids circular import
-
     return get_startup_shortcut_path().exists()
 
 
 __all__ = [
+    "get_startup_shortcut_path",
     "is_installed_windows_run",
     "should_show_installer_welcome",
     "startup_script_exists",

--- a/src/cogstash/ui/install_state.py
+++ b/src/cogstash/ui/install_state.py
@@ -1,0 +1,49 @@
+"""Installer-aware onboarding helpers for CogStash.
+
+Centralises detection of installed-Windows-run vs source/portable, and
+keeps startup-script state accessible without polluting app.py or settings.py.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from cogstash.core.config import CogStashConfig
+
+
+def is_installed_windows_run() -> bool:
+    """Return True when running as a frozen (PyInstaller) Windows installed build."""
+    return sys.platform == "win32" and bool(getattr(sys, "frozen", False))
+
+
+def should_show_installer_welcome(config: CogStashConfig, version: str) -> bool:
+    """Return True when we should show the installer-welcome dialog.
+
+    Conditions:
+    - Running as the installed Windows app (frozen exe).
+    - An existing config exists, i.e. ``last_seen_version`` is non-empty
+      (new users with no config see the full first-run wizard instead).
+    - The recorded version differs from *version* (an upgrade or fresh install
+      over an existing config from a previous installation or portable run).
+    """
+    if not is_installed_windows_run():
+        return False
+    if config.last_seen_version == "":
+        return False
+    return config.last_seen_version != version
+
+
+def startup_script_exists() -> bool:
+    """Return True if the installer-managed startup batch script is present on disk."""
+    if sys.platform != "win32":
+        return False
+    from cogstash.ui.settings import get_startup_shortcut_path  # lazy — avoids circular import
+
+    return get_startup_shortcut_path().exists()
+
+
+__all__ = [
+    "is_installed_windows_run",
+    "should_show_installer_welcome",
+    "startup_script_exists",
+]

--- a/src/cogstash/ui/settings.py
+++ b/src/cogstash/ui/settings.py
@@ -174,6 +174,7 @@ class SettingsWindow:
             startup_state = self.config.launch_at_startup
         if self.config.launch_at_startup != startup_state:
             self.config.launch_at_startup = startup_state
+            save_config(self.config, self.config_path)
         self.launch_var = tk.BooleanVar(value=startup_state)
         tk.Checkbutton(frame, text="Launch CogStash at system startup",
                        variable=self.launch_var, bg=t["bg"], fg=t["fg"],
@@ -841,7 +842,7 @@ class InstallerWelcomeDialog:
                      font=(platform_font(), 9), anchor="w").pack(side="left", fill="x", expand=True)
 
         tk.Label(
-            self.win, text="Startup and PATH settings can be changed in Settings → General.",
+            self.win, text="Startup can be changed in Settings → General. PATH can be changed by re-running the installer.",
             bg=t["bg"], fg=t["muted"], font=(platform_font(), 8), wraplength=370,
         ).pack(pady=(12, 0), padx=24)
 

--- a/src/cogstash/ui/settings.py
+++ b/src/cogstash/ui/settings.py
@@ -172,6 +172,8 @@ class SettingsWindow:
             startup_state = startup_script_exists()
         else:
             startup_state = self.config.launch_at_startup
+        if self.config.launch_at_startup != startup_state:
+            self.config.launch_at_startup = startup_state
         self.launch_var = tk.BooleanVar(value=startup_state)
         tk.Checkbutton(frame, text="Launch CogStash at system startup",
                        variable=self.launch_var, bg=t["bg"], fg=t["fg"],
@@ -704,10 +706,13 @@ class WizardWindow:
     def _finish(self):
         """Save config and close wizard."""
         from cogstash import __version__
+        from cogstash.ui.install_state import is_installed_windows_run
         self.config.output_file = Path(self.notes_file_var.get()).expanduser()
         self.config.theme = self.selected_theme.get()
         self.config.window_size = self.selected_size.get()
         self.config.last_seen_version = __version__
+        if is_installed_windows_run():
+            self.config.last_seen_installer_version = __version__
         save_config(self.config, self.config_path)
         self._close()
 

--- a/src/cogstash/ui/settings.py
+++ b/src/cogstash/ui/settings.py
@@ -16,13 +16,7 @@ from cogstash.ui.app import (
     platform_font,
     save_config,
 )
-
-
-def get_startup_shortcut_path() -> Path:
-    """Get the path where the startup shortcut/script should be placed (Windows)."""
-    import os
-    startup_dir = Path(os.environ.get("APPDATA", "")) / "Microsoft" / "Windows" / "Start Menu" / "Programs" / "Startup"
-    return startup_dir / "CogStash.bat"
+from cogstash.ui.install_state import get_startup_shortcut_path
 
 
 def set_launch_at_startup(enable: bool) -> None:
@@ -842,7 +836,7 @@ class InstallerWelcomeDialog:
                      font=(platform_font(), 9), anchor="w").pack(side="left", fill="x", expand=True)
 
         tk.Label(
-            self.win, text="Startup can be changed in Settings → General. PATH can be changed by re-running the installer.",
+            self.win, text="Startup can be changed in Settings → General. The PATH option is available during installation.",
             bg=t["bg"], fg=t["muted"], font=(platform_font(), 8), wraplength=370,
         ).pack(pady=(12, 0), padx=24)
 

--- a/src/cogstash/ui/settings.py
+++ b/src/cogstash/ui/settings.py
@@ -165,7 +165,14 @@ class SettingsWindow:
         # Section: Launch at Startup
         tk.Label(frame, text="Startup", bg=t["bg"], fg=t["fg"],
                  font=(platform_font(), 11, "bold")).pack(anchor="w", pady=(16, 4))
-        self.launch_var = tk.BooleanVar(value=self.config.launch_at_startup)
+        # Reflect actual on-disk state so installer-created scripts are visible immediately.
+        if sys.platform == "win32":
+            from cogstash.ui.install_state import startup_script_exists  # lazy — keeps install_state optional
+
+            startup_state = startup_script_exists()
+        else:
+            startup_state = self.config.launch_at_startup
+        self.launch_var = tk.BooleanVar(value=startup_state)
         tk.Checkbutton(frame, text="Launch CogStash at system startup",
                        variable=self.launch_var, bg=t["bg"], fg=t["fg"],
                        selectcolor=t["entry_bg"], activebackground=t["bg"],
@@ -776,3 +783,65 @@ class WhatsNewDialog:
         tk.Button(self.win, text="Got it", command=self.win.destroy, bg=t["accent"], fg=t["bg"],
                   relief="flat", font=(platform_font(), 10, "bold"), padx=24, pady=6,
                   cursor="hand2").pack(pady=(16, 20))
+
+
+class InstallerWelcomeDialog:
+    """Lightweight welcome dialog shown once after an installed-Windows upgrade with existing config.
+
+    Informs the user they are now running the installed CogStash, highlights
+    installer-specific features (startup at boot, CLI/PATH), and does NOT
+    force the full first-run wizard.
+    """
+
+    def __init__(self, parent: tk.Tk, config: CogStashConfig, config_path: Path, version: str):
+        self.parent = parent
+        self.config = config
+        self.config_path = config_path
+        self.version = version
+        self.theme = THEMES[config.theme]
+        t = self.theme
+
+        self.win = tk.Toplevel(parent)
+        self.win.title("CogStash Updated")
+        self.win.geometry("420x340")
+        self.win.resizable(False, False)
+        self.win.configure(bg=t["bg"])
+        self.win.transient(parent)
+        self.win.focus_force()
+        self.win.bind("<Escape>", lambda e: self.win.destroy())
+
+        tk.Label(
+            self.win, text="⚡ CogStash Updated", bg=t["bg"], fg=t["fg"],
+            font=(platform_font(), 14, "bold"),
+        ).pack(pady=(20, 4))
+        tk.Label(
+            self.win, text=f"v{version} — installed edition",
+            bg=t["bg"], fg=t["muted"], font=(platform_font(), 10),
+        ).pack(pady=(0, 16))
+
+        info_frame = tk.Frame(self.win, bg=t["entry_bg"], padx=16, pady=12)
+        info_frame.pack(fill="x", padx=24)
+
+        bullets = [
+            ("⚡", "Hotkey capture is ready — press it anywhere"),
+            ("🖥️", "Startup at boot — configured during installation"),
+            ("💻", "CLI available if you chose the PATH option in the installer"),
+        ]
+        for emoji, text in bullets:
+            row = tk.Frame(info_frame, bg=t["entry_bg"])
+            row.pack(fill="x", pady=3)
+            tk.Label(row, text=emoji, bg=t["entry_bg"], fg=t["fg"],
+                     font=(platform_font(), 11), width=3).pack(side="left")
+            tk.Label(row, text=text, bg=t["entry_bg"], fg=t["fg"],
+                     font=(platform_font(), 9), anchor="w").pack(side="left", fill="x", expand=True)
+
+        tk.Label(
+            self.win, text="Startup and PATH settings can be changed in Settings → General.",
+            bg=t["bg"], fg=t["muted"], font=(platform_font(), 8), wraplength=370,
+        ).pack(pady=(12, 0), padx=24)
+
+        tk.Button(
+            self.win, text="Got it", command=self.win.destroy,
+            bg=t["accent"], fg=t["bg"], relief="flat",
+            font=(platform_font(), 10, "bold"), padx=24, pady=6, cursor="hand2",
+        ).pack(pady=(16, 20))

--- a/src/cogstash/ui/settings.py
+++ b/src/cogstash/ui/settings.py
@@ -830,8 +830,8 @@ class InstallerWelcomeDialog:
 
         bullets = [
             ("⚡", "Hotkey capture is ready — press it anywhere"),
-            ("🖥️", "Startup at boot — configured during installation"),
-            ("💻", "CLI available if you chose the PATH option in the installer"),
+            ("🖥️", "Startup at boot — optional during installation or later in Settings"),
+            ("💻", "CLI available if you chose the PATH option during installation"),
         ]
         for emoji, text in bullets:
             row = tk.Frame(info_frame, bg=t["entry_bg"])

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -231,3 +231,34 @@ def test_config_installer_onboarding_not_shown_for_non_installed_run():
     config = CogStashConfig(last_seen_version="0.3.0", last_seen_installer_version="")
     with patch("cogstash.ui.install_state.is_installed_windows_run", return_value=False):
         assert should_show_installer_welcome(config, "0.4.0") is False
+
+
+def test_is_installed_windows_run_requires_marker(monkeypatch, tmp_path):
+    import cogstash.ui.install_state as state_mod
+
+    exe_dir = tmp_path / "portable"
+    exe_dir.mkdir()
+    exe_path = exe_dir / "CogStash.exe"
+    exe_path.write_text("exe", encoding="utf-8")
+
+    monkeypatch.setattr(state_mod.sys, "platform", "win32")
+    monkeypatch.setattr(state_mod.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(state_mod.sys, "executable", str(exe_path))
+
+    assert state_mod.is_installed_windows_run() is False
+
+
+def test_is_installed_windows_run_true_with_marker(monkeypatch, tmp_path):
+    import cogstash.ui.install_state as state_mod
+
+    exe_dir = tmp_path / "installed"
+    exe_dir.mkdir()
+    exe_path = exe_dir / "CogStash.exe"
+    exe_path.write_text("exe", encoding="utf-8")
+    (exe_dir / ".cogstash-installed").write_text("installed", encoding="utf-8")
+
+    monkeypatch.setattr(state_mod.sys, "platform", "win32")
+    monkeypatch.setattr(state_mod.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(state_mod.sys, "executable", str(exe_path))
+
+    assert state_mod.is_installed_windows_run() is True

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -169,3 +169,54 @@ def test_valid_theme_and_window_size_sets_match_ui_runtime():
 
     assert config_mod.VALID_THEMES == set(app_mod.THEMES)
     assert config_mod.VALID_WINDOW_SIZES == set(app_mod.WINDOW_SIZES)
+
+
+# ── Installer-onboarding state ────────────────────────────────────────────────
+
+
+def test_config_installer_onboarding_not_shown_for_new_user():
+    """should_show_installer_welcome returns False when no version recorded (first-run case)."""
+    from unittest.mock import patch
+
+    from cogstash.core.config import CogStashConfig
+    from cogstash.ui.install_state import should_show_installer_welcome
+
+    config = CogStashConfig(last_seen_version="")
+    with patch("cogstash.ui.install_state.is_installed_windows_run", return_value=True):
+        assert should_show_installer_welcome(config, "0.4.0") is False
+
+
+def test_config_installer_onboarding_shown_for_installed_upgrade():
+    """should_show_installer_welcome returns True for installed run with a stale version."""
+    from unittest.mock import patch
+
+    from cogstash.core.config import CogStashConfig
+    from cogstash.ui.install_state import should_show_installer_welcome
+
+    config = CogStashConfig(last_seen_version="0.3.0")
+    with patch("cogstash.ui.install_state.is_installed_windows_run", return_value=True):
+        assert should_show_installer_welcome(config, "0.4.0") is True
+
+
+def test_config_installer_onboarding_not_shown_when_version_matches():
+    """should_show_installer_welcome returns False when already up to date."""
+    from unittest.mock import patch
+
+    from cogstash.core.config import CogStashConfig
+    from cogstash.ui.install_state import should_show_installer_welcome
+
+    config = CogStashConfig(last_seen_version="0.4.0")
+    with patch("cogstash.ui.install_state.is_installed_windows_run", return_value=True):
+        assert should_show_installer_welcome(config, "0.4.0") is False
+
+
+def test_config_installer_onboarding_not_shown_for_non_installed_run():
+    """should_show_installer_welcome returns False when not running as installed app."""
+    from unittest.mock import patch
+
+    from cogstash.core.config import CogStashConfig
+    from cogstash.ui.install_state import should_show_installer_welcome
+
+    config = CogStashConfig(last_seen_version="0.3.0")
+    with patch("cogstash.ui.install_state.is_installed_windows_run", return_value=False):
+        assert should_show_installer_welcome(config, "0.4.0") is False

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -123,6 +123,7 @@ def test_config_new_fields_defaults(tmp_path):
 
     assert config.launch_at_startup is False
     assert config.last_seen_version == ""
+    assert config.last_seen_installer_version == ""
 
 
 def test_config_new_fields_roundtrip(tmp_path):
@@ -130,7 +131,14 @@ def test_config_new_fields_roundtrip(tmp_path):
 
     config_path = tmp_path / ".cogstash.json"
     config_path.write_text(
-        json.dumps({"launch_at_startup": True, "last_seen_version": "0.1.0", "theme": "dracula"}),
+        json.dumps(
+            {
+                "launch_at_startup": True,
+                "last_seen_version": "0.1.0",
+                "last_seen_installer_version": "0.1.0",
+                "theme": "dracula",
+            }
+        ),
         encoding="utf-8",
     )
 
@@ -138,6 +146,7 @@ def test_config_new_fields_roundtrip(tmp_path):
 
     assert config.launch_at_startup is True
     assert config.last_seen_version == "0.1.0"
+    assert config.last_seen_installer_version == "0.1.0"
     assert config.theme == "dracula"
 
 
@@ -150,6 +159,7 @@ def test_save_config(tmp_path):
         theme="dracula",
         window_size="wide",
         last_seen_version="0.2.0",
+        last_seen_installer_version="0.2.0",
     )
     config_path = tmp_path / ".cogstash.json"
 
@@ -159,6 +169,7 @@ def test_save_config(tmp_path):
     assert data["theme"] == "dracula"
     assert data["window_size"] == "wide"
     assert data["last_seen_version"] == "0.2.0"
+    assert data["last_seen_installer_version"] == "0.2.0"
     assert data["launch_at_startup"] is False
     assert Path(data["output_file"]) == tmp_path / "notes.md"
 
@@ -181,19 +192,19 @@ def test_config_installer_onboarding_not_shown_for_new_user():
     from cogstash.core.config import CogStashConfig
     from cogstash.ui.install_state import should_show_installer_welcome
 
-    config = CogStashConfig(last_seen_version="")
+    config = CogStashConfig(last_seen_version="", last_seen_installer_version="")
     with patch("cogstash.ui.install_state.is_installed_windows_run", return_value=True):
         assert should_show_installer_welcome(config, "0.4.0") is False
 
 
-def test_config_installer_onboarding_shown_for_installed_upgrade():
-    """should_show_installer_welcome returns True for installed run with a stale version."""
+def test_config_installer_onboarding_shown_for_first_installed_launch():
+    """should_show_installer_welcome returns True when an existing config has never seen the installed build."""
     from unittest.mock import patch
 
     from cogstash.core.config import CogStashConfig
     from cogstash.ui.install_state import should_show_installer_welcome
 
-    config = CogStashConfig(last_seen_version="0.3.0")
+    config = CogStashConfig(last_seen_version="0.4.0", last_seen_installer_version="")
     with patch("cogstash.ui.install_state.is_installed_windows_run", return_value=True):
         assert should_show_installer_welcome(config, "0.4.0") is True
 
@@ -205,7 +216,7 @@ def test_config_installer_onboarding_not_shown_when_version_matches():
     from cogstash.core.config import CogStashConfig
     from cogstash.ui.install_state import should_show_installer_welcome
 
-    config = CogStashConfig(last_seen_version="0.4.0")
+    config = CogStashConfig(last_seen_version="0.4.0", last_seen_installer_version="0.4.0")
     with patch("cogstash.ui.install_state.is_installed_windows_run", return_value=True):
         assert should_show_installer_welcome(config, "0.4.0") is False
 
@@ -217,6 +228,6 @@ def test_config_installer_onboarding_not_shown_for_non_installed_run():
     from cogstash.core.config import CogStashConfig
     from cogstash.ui.install_state import should_show_installer_welcome
 
-    config = CogStashConfig(last_seen_version="0.3.0")
+    config = CogStashConfig(last_seen_version="0.3.0", last_seen_installer_version="")
     with patch("cogstash.ui.install_state.is_installed_windows_run", return_value=False):
         assert should_show_installer_welcome(config, "0.4.0") is False

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -112,7 +112,6 @@ def test_inno_setup_script_records_startup_state_contract():
     repo_root = Path(__file__).resolve().parents[1]
     iss_path = repo_root / "installer" / "windows" / "CogStash.iss"
     content = iss_path.read_text(encoding="utf-8")
-    assert "CogStash.bat" in content
     # This must become a real installer/app state contract in a follow-up task,
     # not just an arbitrary comment string that happens to mention startup.
     assert "launch_at_startup" in content or "installer-state" in content

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -104,11 +104,12 @@ def test_inno_setup_script_coordinates_with_running_app_on_uninstall():
     assert "CloseApplications" in content or "AppMutex" in content
 
 
-def test_installer_docs_or_script_record_startup_state_contract():
-    """Installer docs or script should record startup/config sync contract (regression lock)."""
+def test_inno_setup_script_records_startup_state_contract():
+    """Installer script should record the startup/config sync contract (regression lock)."""
     repo_root = Path(__file__).resolve().parents[1]
     iss_path = repo_root / "installer" / "windows" / "CogStash.iss"
     content = iss_path.read_text(encoding="utf-8")
+    assert "CogStash.bat" in content
     assert "launch_at_startup" in content or "installer-state" in content
 
 

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -112,14 +112,18 @@ def test_inno_setup_script_coordinates_with_running_app_on_uninstall():
     assert "CloseApplications=yes" in content
 
 
-def test_inno_setup_script_records_startup_state_contract():
-    """Installer script should record the startup/config sync contract (regression lock)."""
+def test_installed_startup_state_contract_is_implemented_in_config_and_ui():
+    """Installed startup/config sync should be backed by config + UI code, not an installer comment marker."""
     repo_root = Path(__file__).resolve().parents[1]
-    iss_path = repo_root / "installer" / "windows" / "CogStash.iss"
-    content = iss_path.read_text(encoding="utf-8")
-    # This must become a real installer/app state contract in a follow-up task,
-    # not just an arbitrary comment string that happens to mention startup.
-    assert "launch_at_startup" in content or "installer-state" in content
+    config_path = repo_root / "src" / "cogstash" / "core" / "config.py"
+    settings_path = repo_root / "src" / "cogstash" / "ui" / "settings.py"
+
+    config_content = config_path.read_text(encoding="utf-8")
+    settings_content = settings_path.read_text(encoding="utf-8")
+
+    assert "last_seen_installer_version" in config_content
+    assert "startup_script_exists" in settings_content
+    assert "self.config.launch_at_startup = startup_state" in settings_content
 
 
 def test_stage_windows_payload_copies_bundle_and_renames_exe(tmp_path):

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -58,33 +58,28 @@ def test_inno_setup_script_supports_optional_startup_task():
     assert 'Type: files; Name: "{userstartup}\\CogStash.bat"' in content
 
 
-def test_inno_setup_script_does_not_offer_path_task():
-    """Installer should no longer offer PATH mutation tasks."""
+def test_inno_setup_script_offers_optional_path_task_with_correct_description():
+    """Installer script should offer an optional PATH task with the correct CLI description."""
     repo_root = Path(__file__).resolve().parents[1]
     iss_path = repo_root / "installer" / "windows" / "CogStash.iss"
 
     content = iss_path.read_text(encoding="utf-8")
 
-    assert 'Name: "addtopath"; Description: "Add CogStash to PATH' not in content
-    assert "EnvAddPath" not in content
-    assert "EnvRemovePath" not in content
-    assert "ChangesEnvironment=yes" not in content
+    assert 'Name: "addtopath"; Description: "Add CogStash CLI to PATH"' in content
+    assert "ChangesEnvironment=yes" in content
+    assert "ExpandConstant('{app}')" in content
 
 
-def test_inno_setup_script_does_not_track_path_ownership():
-    """Installer should not include PATH ownership or cleanup code."""
+def test_inno_setup_script_manages_installer_owned_path():
+    """Installer script should add PATH and track ownership for safe removal on uninstall."""
     repo_root = Path(__file__).resolve().parents[1]
     iss_path = repo_root / "installer" / "windows" / "CogStash.iss"
 
     content = iss_path.read_text(encoding="utf-8")
 
-    assert "PathOwnershipMarkerPath" not in content
-    assert "PathOwnershipMarkerExists" not in content
-    assert "WritePathOwnershipMarker" not in content
-    assert "RemovePathOwnershipMarker" not in content
-    assert "AddPathEntry" not in content
-    assert "RemovePathEntry" not in content
-    assert "RegWriteExpandStringValue" not in content
+    assert "RegWriteExpandStringValue" in content
+    assert "RegDeleteValue" in content
+    assert "PathOwnershipKey" in content
 
 
 def test_inno_setup_script_offers_optional_path_task():
@@ -358,4 +353,6 @@ def test_installer_script_installs_cli_binary_without_shortcut():
 
     iss = iss_path.read_text(encoding="utf-8")
     assert "CogStash-CLI.exe" in iss
-    assert "CogStash CLI" not in iss
+    # No Start Menu or Desktop shortcut entries for CogStash CLI
+    assert 'Name: "{group}\\CogStash CLI"' not in iss
+    assert 'Name: "{autodesktop}\\CogStash CLI"' not in iss

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -77,9 +77,22 @@ def test_inno_setup_script_manages_installer_owned_path():
 
     content = iss_path.read_text(encoding="utf-8")
 
+    # Ownership registry key and write/delete operations must be present.
+    assert "PathOwnershipKey" in content
     assert "RegWriteExpandStringValue" in content
     assert "RegDeleteValue" in content
-    assert "PathOwnershipKey" in content
+
+    # Must use a segment-safe helper rather than raw StringReplace.
+    assert "RemoveExactPathSegment" in content
+    assert "StringReplace" not in content
+
+    # Helper must split on semicolons — the delimiter for PATH segments.
+    assert "Pos(';', " in content or "SemiPos" in content
+
+    # Uninstall hook must call the removal procedure at the right step.
+    assert "CurUninstallStepChanged" in content
+    assert "usPostUninstall" in content
+    assert "RemoveInstallerOwnedPath()" in content
 
 
 def test_inno_setup_script_offers_optional_path_task():

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -87,6 +87,31 @@ def test_inno_setup_script_does_not_track_path_ownership():
     assert "RegWriteExpandStringValue" not in content
 
 
+def test_inno_setup_script_offers_optional_path_task():
+    """Installer script should offer an optional PATH integration task (regression lock)."""
+    repo_root = Path(__file__).resolve().parents[1]
+    iss_path = repo_root / "installer" / "windows" / "CogStash.iss"
+    content = iss_path.read_text(encoding="utf-8")
+    assert 'Name: "addtopath"' in content
+    assert "ChangesEnvironment=yes" in content
+
+
+def test_inno_setup_script_coordinates_with_running_app_on_uninstall():
+    """Installer script should coordinate with running app on uninstall (regression lock)."""
+    repo_root = Path(__file__).resolve().parents[1]
+    iss_path = repo_root / "installer" / "windows" / "CogStash.iss"
+    content = iss_path.read_text(encoding="utf-8")
+    assert "CloseApplications" in content or "AppMutex" in content
+
+
+def test_installer_docs_or_script_record_startup_state_contract():
+    """Installer docs or script should record startup/config sync contract (regression lock)."""
+    repo_root = Path(__file__).resolve().parents[1]
+    iss_path = repo_root / "installer" / "windows" / "CogStash.iss"
+    content = iss_path.read_text(encoding="utf-8")
+    assert "launch_at_startup" in content or "installer-state" in content
+
+
 def test_stage_windows_payload_copies_bundle_and_renames_exe(tmp_path):
     """Stage helper should normalize app names and include the CLI executable."""
     module = _load_build_installer_module()

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -109,10 +109,7 @@ def test_inno_setup_script_coordinates_with_running_app_on_uninstall():
     repo_root = Path(__file__).resolve().parents[1]
     iss_path = repo_root / "installer" / "windows" / "CogStash.iss"
     content = iss_path.read_text(encoding="utf-8")
-    # Task 1 keeps this broad so the next green implementation can choose either
-    # installer-close coordination or explicit mutex-based protection, but the
-    # eventual Task 2 fix must cover uninstall of a still-running tray app.
-    assert "CloseApplications" in content or "AppMutex" in content
+    assert "CloseApplications=yes" in content
 
 
 def test_inno_setup_script_records_startup_state_contract():

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -117,13 +117,19 @@ def test_installed_startup_state_contract_is_implemented_in_config_and_ui():
     repo_root = Path(__file__).resolve().parents[1]
     config_path = repo_root / "src" / "cogstash" / "core" / "config.py"
     settings_path = repo_root / "src" / "cogstash" / "ui" / "settings.py"
+    install_state_path = repo_root / "src" / "cogstash" / "ui" / "install_state.py"
+    iss_path = repo_root / "installer" / "windows" / "CogStash.iss"
 
     config_content = config_path.read_text(encoding="utf-8")
     settings_content = settings_path.read_text(encoding="utf-8")
+    install_state_content = install_state_path.read_text(encoding="utf-8")
+    iss_content = iss_path.read_text(encoding="utf-8")
 
     assert "last_seen_installer_version" in config_content
     assert "startup_script_exists" in settings_content
     assert "self.config.launch_at_startup = startup_state" in settings_content
+    assert "INSTALL_MARKER_NAME" in install_state_content
+    assert ".cogstash-installed" in iss_content
 
 
 def test_stage_windows_payload_copies_bundle_and_renames_exe(tmp_path):

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -101,6 +101,9 @@ def test_inno_setup_script_coordinates_with_running_app_on_uninstall():
     repo_root = Path(__file__).resolve().parents[1]
     iss_path = repo_root / "installer" / "windows" / "CogStash.iss"
     content = iss_path.read_text(encoding="utf-8")
+    # Task 1 keeps this broad so the next green implementation can choose either
+    # installer-close coordination or explicit mutex-based protection, but the
+    # eventual Task 2 fix must cover uninstall of a still-running tray app.
     assert "CloseApplications" in content or "AppMutex" in content
 
 
@@ -110,6 +113,8 @@ def test_inno_setup_script_records_startup_state_contract():
     iss_path = repo_root / "installer" / "windows" / "CogStash.iss"
     content = iss_path.read_text(encoding="utf-8")
     assert "CogStash.bat" in content
+    # This must become a real installer/app state contract in a follow-up task,
+    # not just an arbitrary comment string that happens to mention startup.
     assert "launch_at_startup" in content or "installer-state" in content
 
 

--- a/tests/ui/test_app.py
+++ b/tests/ui/test_app.py
@@ -276,3 +276,77 @@ def test_app_main_installer_welcome_shown_for_installed_upgrade(monkeypatch, tmp
                 app_mod.logger.addHandler(handler)
 
     assert len(welcome_calls) == 1, "InstallerWelcomeDialog should have been shown exactly once"
+
+
+def test_app_main_installer_welcome_shown_for_first_installed_launch(monkeypatch, tmp_path):
+    """An installed launch over an existing same-version config should still show the installer welcome once."""
+    import types
+
+    import cogstash
+    import cogstash.ui.app as app_mod
+    import cogstash.ui.install_state as install_state_mod
+    import cogstash.ui.settings as settings_mod
+
+    welcome_calls: list = []
+    saved_configs: list = []
+
+    config = app_mod.CogStashConfig(
+        output_file=tmp_path / "notes.md",
+        log_file=tmp_path / "cogstash.log",
+        last_seen_version=cogstash.__version__,
+        last_seen_installer_version="",
+    )
+
+    class FakeRoot:
+        def mainloop(self):
+            return None
+
+    class FakeApp:
+        def __init__(self, _root, _config):
+            self.queue = object()
+
+    class FakeGuard:
+        def close(self):
+            return None
+
+    class FakeListener:
+        def __init__(self, _mapping):
+            pass
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    windows_mod = types.ModuleType("cogstash.ui.windows")
+    windows_mod.WINDOWS_MUTEX_NAME = "Local\\CogStash.Test"
+    windows_mod.acquire_single_instance = lambda _name: FakeGuard()
+
+    monkeypatch.setattr(app_mod, "load_config", lambda _path: config)
+    monkeypatch.setattr(app_mod, "configure_dpi", lambda: None)
+    monkeypatch.setattr(app_mod.tk, "Tk", lambda: FakeRoot())
+    monkeypatch.setattr(app_mod, "CogStash", FakeApp)
+    monkeypatch.setattr(app_mod, "create_tray_icon", lambda _queue, _config: None)
+    monkeypatch.setattr(app_mod.keyboard, "GlobalHotKeys", FakeListener)
+    monkeypatch.setattr(app_mod, "save_config", lambda c, _p: saved_configs.append(c.last_seen_installer_version))
+    monkeypatch.setattr(install_state_mod, "is_installed_windows_run", lambda: True)
+    monkeypatch.setattr(settings_mod, "InstallerWelcomeDialog", lambda *a, **kw: welcome_calls.append(a), raising=False)
+    monkeypatch.setitem(sys.modules, "cogstash.ui.windows", windows_mod)
+
+    original_handlers = app_mod.logger.handlers[:]
+    try:
+        app_mod.main()
+    finally:
+        for handler in [h for h in app_mod.logger.handlers[:] if h not in original_handlers]:
+            app_mod.logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+        for handler in original_handlers:
+            if handler not in app_mod.logger.handlers:
+                app_mod.logger.addHandler(handler)
+
+    assert len(welcome_calls) == 1
+    assert saved_configs == [cogstash.__version__]

--- a/tests/ui/test_app.py
+++ b/tests/ui/test_app.py
@@ -206,3 +206,73 @@ def test_app_main_closes_removed_handlers(monkeypatch, tmp_path):
             handler.close()
 
     assert old_handler.closed_flag is True
+
+
+def test_app_main_installer_welcome_shown_for_installed_upgrade(monkeypatch, tmp_path):
+    """When running as an installed app with a stale version, show the installer welcome dialog."""
+    import types
+
+    import cogstash.ui.app as app_mod
+    import cogstash.ui.install_state as install_state_mod
+    import cogstash.ui.settings as settings_mod
+
+    welcome_calls: list = []
+
+    config = app_mod.CogStashConfig(
+        output_file=tmp_path / "notes.md",
+        log_file=tmp_path / "cogstash.log",
+        last_seen_version="0.3.0",
+    )
+
+    class FakeRoot:
+        def mainloop(self):
+            return None
+
+    class FakeApp:
+        def __init__(self, _root, _config):
+            self.queue = object()
+
+    class FakeGuard:
+        def close(self):
+            return None
+
+    class FakeListener:
+        def __init__(self, _mapping):
+            pass
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    windows_mod = types.ModuleType("cogstash.ui.windows")
+    windows_mod.WINDOWS_MUTEX_NAME = "Local\\CogStash.Test"
+    windows_mod.acquire_single_instance = lambda _name: FakeGuard()
+
+    monkeypatch.setattr(app_mod, "load_config", lambda _path: config)
+    monkeypatch.setattr(app_mod, "configure_dpi", lambda: None)
+    monkeypatch.setattr(app_mod.tk, "Tk", lambda: FakeRoot())
+    monkeypatch.setattr(app_mod, "CogStash", FakeApp)
+    monkeypatch.setattr(app_mod, "create_tray_icon", lambda _queue, _config: None)
+    monkeypatch.setattr(app_mod.keyboard, "GlobalHotKeys", FakeListener)
+    monkeypatch.setattr(app_mod, "save_config", lambda _c, _p: None)
+    monkeypatch.setattr(install_state_mod, "is_installed_windows_run", lambda: True)
+    monkeypatch.setattr(settings_mod, "InstallerWelcomeDialog", lambda *a, **kw: welcome_calls.append(a), raising=False)
+    monkeypatch.setitem(sys.modules, "cogstash.ui.windows", windows_mod)
+
+    original_handlers = app_mod.logger.handlers[:]
+    try:
+        app_mod.main()
+    finally:
+        for handler in [h for h in app_mod.logger.handlers[:] if h not in original_handlers]:
+            app_mod.logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+        for handler in original_handlers:
+            if handler not in app_mod.logger.handlers:
+                app_mod.logger.addHandler(handler)
+
+    assert len(welcome_calls) == 1, "InstallerWelcomeDialog should have been shown exactly once"

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -87,4 +87,26 @@ def test_settings_startup_script_state_reflects_disk(tk_root, tmp_path, monkeypa
     sw = SettingsWindow(tk_root, config, tmp_path / "test.json")
 
     assert sw.launch_var.get() is True, "checkbox should reflect disk state (True), not config (False)"
+    assert config.launch_at_startup is True, "config should self-heal to the on-disk startup state"
     sw.win.destroy()
+
+
+@needs_display
+def test_wizard_records_installed_version_for_installed_runs(tk_root, tmp_path, monkeypatch):
+    """Completing the full wizard on an installed build should also record the installed version marker."""
+    import cogstash
+    import cogstash.ui.install_state as state_mod
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.settings import WizardWindow
+
+    monkeypatch.setattr(state_mod, "is_installed_windows_run", lambda: True)
+
+    config = CogStashConfig()
+    config_path = tmp_path / ".cogstash.json"
+    wiz = WizardWindow(tk_root, config, config_path)
+    wiz._finish()
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert data["last_seen_version"] == cogstash.__version__
+    assert data["last_seen_installer_version"] == cogstash.__version__
+    wiz.win.destroy()

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -65,7 +65,7 @@ def test_wizard_saves_config(tk_root, tmp_path):
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
 def test_startup_shortcut_path():
     """get_startup_shortcut_path returns valid Windows startup path."""
-    from cogstash.ui.settings import get_startup_shortcut_path
+    from cogstash.ui.install_state import get_startup_shortcut_path
 
     path = get_startup_shortcut_path()
     assert "Startup" in str(path) or "startup" in str(path)
@@ -124,7 +124,8 @@ def test_installer_welcome_dialog_does_not_claim_path_is_changeable_in_settings(
     dialog = InstallerWelcomeDialog(tk_root, CogStashConfig(), tmp_path / ".cogstash.json", "0.4.0")
     labels = [child.cget("text") for child in dialog.win.winfo_children() if child.winfo_class() == "Label"]
 
-    assert any("PATH can be changed by re-running the installer" in text for text in labels)
+    assert any("PATH option is available during installation." in text for text in labels)
+    assert not any("PATH can be changed by re-running the installer" in text for text in labels)
     assert not any("Startup and PATH settings can be changed in Settings" in text for text in labels)
 
     dialog.win.destroy()

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -70,3 +70,21 @@ def test_startup_shortcut_path():
     path = get_startup_shortcut_path()
     assert "Startup" in str(path) or "startup" in str(path)
     assert str(path).endswith(".bat")
+
+
+@needs_display
+def test_settings_startup_script_state_reflects_disk(tk_root, tmp_path, monkeypatch):
+    """Startup checkbox must reflect actual on-disk script presence, not just config value."""
+    import cogstash.ui.install_state as state_mod
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
+
+    # Disk has the startup script but config says False (e.g. installer created .bat, config not yet synced)
+    monkeypatch.setattr(state_mod, "startup_script_exists", lambda: True)
+    monkeypatch.setattr("sys.platform", "win32")
+
+    config = CogStashConfig(launch_at_startup=False)
+    sw = SettingsWindow(tk_root, config, tmp_path / "test.json")
+
+    assert sw.launch_var.get() is True, "checkbox should reflect disk state (True), not config (False)"
+    sw.win.destroy()

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -84,10 +84,13 @@ def test_settings_startup_script_state_reflects_disk(tk_root, tmp_path, monkeypa
     monkeypatch.setattr("sys.platform", "win32")
 
     config = CogStashConfig(launch_at_startup=False)
-    sw = SettingsWindow(tk_root, config, tmp_path / "test.json")
+    config_path = tmp_path / "test.json"
+    sw = SettingsWindow(tk_root, config, config_path)
 
     assert sw.launch_var.get() is True, "checkbox should reflect disk state (True), not config (False)"
     assert config.launch_at_startup is True, "config should self-heal to the on-disk startup state"
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert data["launch_at_startup"] is True, "self-healed startup state should be persisted to config"
     sw.win.destroy()
 
 
@@ -110,3 +113,18 @@ def test_wizard_records_installed_version_for_installed_runs(tk_root, tmp_path, 
     assert data["last_seen_version"] == cogstash.__version__
     assert data["last_seen_installer_version"] == cogstash.__version__
     wiz.win.destroy()
+
+
+@needs_display
+def test_installer_welcome_dialog_does_not_claim_path_is_changeable_in_settings(tk_root, tmp_path):
+    """Installer welcome copy should not imply PATH can be changed from Settings."""
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.settings import InstallerWelcomeDialog
+
+    dialog = InstallerWelcomeDialog(tk_root, CogStashConfig(), tmp_path / ".cogstash.json", "0.4.0")
+    labels = [child.cget("text") for child in dialog.win.winfo_children() if child.winfo_class() == "Label"]
+
+    assert any("PATH can be changed by re-running the installer" in text for text in labels)
+    assert not any("Startup and PATH settings can be changed in Settings" in text for text in labels)
+
+    dialog.win.destroy()


### PR DESCRIPTION
## Summary
- fix Windows installer PATH integration and uninstall coordination regressions
- add installer-aware onboarding plus startup/config state reconciliation
- refresh README to match current installer, onboarding, and CLI behavior

Closes #9

## Test Plan
- [x] uv run pytest tests\\ -q
- [x] uv run ruff check src\\ tests\\
- [x] uv run mypy src\\cogstash\\
- [x] uv run pytest tests\\test_build_installer.py -v
- [x] uv run python scripts\\build.py --target cli
- [x] uv run python scripts\\build.py --target ui