### PR TITLE
fix: surface hotkey registration failures

### DIFF
--- a/docs/superpowers/plans/2026-04-12-hotkey-failure-feedback.md
+++ b/docs/superpowers/plans/2026-04-12-hotkey-failure-feedback.md
@@ -1,0 +1,310 @@
+# Hotkey Failure Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add clear in-app feedback when global hotkey registration fails by showing a startup warning dialog and a persistent Settings warning for the current session.
+
+**Architecture:** Keep this slice runtime-only. Detect the registration failure in `ui.app`, preserve the existing log/console output, and thread a small failure message through the live app/session state into `SettingsWindow` so the warning is visible without introducing new persisted config. Tests should lock both the startup modal behavior and the Settings warning copy.
+
+**Tech Stack:** Python 3.9+, tkinter, pynput, pytest
+
+---
+
+## File Map
+
+- Modify: `src/cogstash/ui/app.py`
+  - capture hotkey registration failure details during startup
+  - show a startup warning dialog
+  - keep a runtime/session warning string on the app instance
+  - pass the warning into Settings when opened
+- Modify: `src/cogstash/ui/settings.py`
+  - accept an optional hotkey failure warning input
+  - render a visible warning block in General tab when present
+- Modify: `tests/ui/test_app.py`
+  - add focused startup-failure regression tests
+- Modify: `tests/ui/test_settings.py`
+  - add focused Settings warning tests
+
+## Implementation notes
+
+- This plan intentionally does **not** solve hotkey editing UX; that belongs to `#14`.
+- The startup warning must be accurate with current behavior: users can inspect logs and adjust config, but not yet edit the hotkey directly in Settings.
+- Keep the session state simple: one optional warning message string is enough.
+- Do not persist this warning to config.
+
+### Task 1: Lock startup failure UX with failing tests
+
+**Files:**
+- Modify: `tests/ui/test_app.py`
+- Test: `tests/ui/test_app.py`
+
+- [ ] **Step 1: Write a failing app test for startup warning on hotkey registration failure**
+
+```python
+def test_app_main_shows_warning_when_hotkey_registration_fails(monkeypatch, tmp_path):
+    ...
+    monkeypatch.setattr(app_mod.keyboard, "GlobalHotKeys", FailingListener)
+    monkeypatch.setattr(app_mod.messagebox, "showwarning", lambda *a, **kw: warnings.append((a, kw)))
+    ...
+    app_mod.main()
+    assert len(warnings) == 1
+```
+
+- [ ] **Step 2: Write a failing app test that startup still completes after the warning**
+
+```python
+def test_app_main_continues_startup_after_hotkey_registration_failure(monkeypatch, tmp_path):
+    ...
+    assert "CogStash is running." in output
+    assert created_apps == [True]
+```
+
+- [ ] **Step 3: Write a failing app test that healthy startup does not show the warning**
+
+```python
+def test_app_main_does_not_show_hotkey_warning_when_registration_succeeds(monkeypatch, tmp_path):
+    ...
+    monkeypatch.setattr(app_mod.keyboard, "GlobalHotKeys", FakeListener)
+    monkeypatch.setattr(app_mod.messagebox, "showwarning", lambda *a, **kw: warnings.append((a, kw)))
+    ...
+    app_mod.main()
+    assert warnings == []
+```
+
+- [ ] **Step 4: Tighten the app warning assertions around real guidance copy**
+
+The startup-warning test must verify the warning text includes:
+- the configured hotkey
+- that capture is unavailable for this session
+- the log file path
+- that another app may already be using the shortcut
+- that platform permissions/accessibility hooks may be blocking registration
+- that the user can change the hotkey in config for now, then restart CogStash
+
+- [ ] **Step 5: Run the focused app tests to verify they fail**
+
+Run: `uv run pytest tests\ui\test_app.py -k "hotkey_registration_failure or hotkey_warning" -v`
+Expected: FAIL because no GUI warning or runtime warning state exists yet.
+
+- [ ] **Step 6: Commit the red app tests**
+
+```bash
+git add tests/ui/test_app.py
+git commit -m "test: cover hotkey registration failure feedback"
+```
+
+### Task 2: Lock Settings warning behavior with failing tests
+
+**Files:**
+- Modify: `tests/ui/test_settings.py`
+- Modify: `tests/ui/test_app.py`
+- Test: `tests/ui/test_settings.py`
+
+- [ ] **Step 1: Write a failing Settings test for visible hotkey failure warning**
+
+```python
+@needs_display
+def test_settings_shows_hotkey_registration_warning(tk_root, tmp_path):
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
+
+    sw = SettingsWindow(
+        tk_root,
+        CogStashConfig(),
+        tmp_path / "test.json",
+        hotkey_warning="Hotkey failed to register: <ctrl>+<shift>+<space>",
+    )
+    labels = [child.cget("text") for child in sw.tab_frames[0].winfo_children() if child.winfo_class() == "Label"]
+    assert any("failed to register" in text for text in labels)
+    sw.win.destroy()
+```
+
+- [ ] **Step 2: Write a failing Settings test that no warning is shown when there is no failure**
+
+```python
+@needs_display
+def test_settings_hides_hotkey_warning_when_session_is_healthy(tk_root, tmp_path):
+    ...
+    assert not any("failed to register" in text for text in labels)
+```
+
+- [ ] **Step 3: Write a failing integration test in `tests/ui/test_app.py` that app state reaches Settings**
+
+Add an app-level test that:
+- simulates hotkey registration failure in `main()` / app startup flow
+- opens Settings through `CogStash._open_settings()` or equivalent wiring point
+- verifies the Settings warning receives the runtime failure state
+
+- [ ] **Step 4: Tighten the Settings warning assertions around real guidance copy**
+
+The Settings warning test must verify:
+- it says the hotkey failed to register
+- it says capture is unavailable until the issue is fixed/restarted
+- it points to the log file
+- it does **not** claim hotkey can already be edited in Settings
+
+- [ ] **Step 5: Run the focused Settings tests to verify they fail**
+
+Run: `uv run pytest tests\ui\test_settings.py -k "hotkey_warning" -v`
+Expected: FAIL because `SettingsWindow` has no such parameter or warning block yet.
+
+- [ ] **Step 6: Commit the red Settings tests**
+
+```bash
+git add tests/ui/test_settings.py
+git commit -m "test: lock settings hotkey warning UX"
+```
+
+### Task 3: Implement runtime hotkey failure state and startup modal
+
+**Files:**
+- Modify: `src/cogstash/ui/app.py`
+- Test: `tests/ui/test_app.py`
+
+- [ ] **Step 1: Add a small runtime/session field for hotkey warning state**
+
+Implementation shape:
+
+```python
+class CogStash:
+    def __init__(...):
+        ...
+        self.hotkey_warning: str | None = None
+```
+
+- [ ] **Step 2: Pass the warning state into `SettingsWindow`**
+
+Update `_open_settings()`:
+
+```python
+self._settings_win = SettingsWindow(
+    self.root,
+    self.config,
+    self.config_path,
+    on_config_changed=self._on_config_changed,
+    hotkey_warning=self.hotkey_warning,
+)
+```
+
+- [ ] **Step 3: On hotkey registration failure, build a user-facing warning string**
+
+Implementation should include:
+- configured hotkey
+- log file path
+- plain next-step guidance
+
+- [ ] **Step 4: Show `messagebox.showwarning(...)` once during startup**
+
+This must happen only on the failure path and must not prevent startup from completing.
+
+- [ ] **Step 5: Keep existing logger + console output intact**
+
+Do not remove:
+- `logger.error(...)`
+- `safe_print(...)`
+
+- [ ] **Step 6: Re-run focused app tests until they pass**
+
+Run: `uv run pytest tests\ui\test_app.py -k "hotkey_registration_failure or hotkey_warning" -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit the app implementation**
+
+```bash
+git add src/cogstash/ui/app.py tests/ui/test_app.py
+git commit -m "fix: surface hotkey registration failures"
+```
+
+### Task 4: Implement persistent Settings warning
+
+**Files:**
+- Modify: `src/cogstash/ui/settings.py`
+- Test: `tests/ui/test_settings.py`
+
+- [ ] **Step 1: Extend `SettingsWindow` to accept an optional `hotkey_warning`**
+
+Implementation shape:
+
+```python
+def __init__(..., hotkey_warning: str | None = None):
+    self.hotkey_warning = hotkey_warning
+```
+
+- [ ] **Step 2: Render a warning block near the General tab hotkey section**
+
+The warning block should:
+- be visually distinct
+- state that the current hotkey failed to register
+- explain that global capture is unavailable until restart/fix
+- point to the log file / config path accurately
+
+- [ ] **Step 3: Keep copy accurate with current product behavior**
+
+Do **not** claim:
+- hotkey can already be changed directly in Settings
+- the warning persists across restarts
+
+- [ ] **Step 4: Re-run focused Settings tests until they pass**
+
+Run: `uv run pytest tests\ui\test_settings.py -k "hotkey_warning" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit the Settings implementation**
+
+```bash
+git add src/cogstash/ui/settings.py tests/ui/test_settings.py
+git commit -m "feat: show persistent hotkey failure warning"
+```
+
+### Task 5: Full verification and issue tracking
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-12-hotkey-failure-feedback.md` only if review reveals spec drift
+- Modify: `docs/superpowers/plans/2026-04-12-hotkey-failure-feedback.md` only if review reveals plan drift
+- GitHub issue: `#15`
+
+- [ ] **Step 1: Run the focused UX regression suite**
+
+Run:
+
+```bash
+uv run pytest tests\ui\test_app.py -v
+uv run pytest tests\ui\test_settings.py -v
+```
+
+Expected: PASS
+
+- [ ] **Step 2: Run repository quality checks**
+
+Run:
+
+```bash
+uv run ruff check src\ tests\
+uv run mypy src\cogstash\
+uv run pytest tests\ -q
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Update the child issue with spec/plan + execution status**
+
+At minimum:
+- link or reference the spec document
+- link or reference the implementation plan
+- note that implementation has started on the feature branch
+
+- [ ] **Step 4: Request review before closing the child**
+
+Review must confirm:
+- startup modal appears only on failure
+- startup still completes
+- Settings warning is present only in the failed session
+- runtime failure state is actually threaded from app startup into Settings
+- copy is accurate and does not overpromise hotkey editing
+
+- [ ] **Step 5: After review + push/PR, update and close the child issue**
+
+At minimum:
+- comment with what shipped
+- link the PR
+- close `#15`

--- a/docs/superpowers/specs/2026-04-12-hotkey-failure-feedback.md
+++ b/docs/superpowers/specs/2026-04-12-hotkey-failure-feedback.md
@@ -1,0 +1,88 @@
+# Hotkey Registration Failure Feedback Spec
+
+## Parent issue
+- Child issue: `#15` — Show clear in-app feedback when hotkey registration fails
+- Umbrella: `#11` — Post-v0.4.1 UX and workflow follow-up
+
+## Problem
+
+When `pynput.keyboard.GlobalHotKeys` fails to register the configured hotkey, CogStash currently logs the error and prints a console message, but the GUI provides no durable, user-facing indication that the main capture workflow is broken.
+
+This creates a bad UX: the app appears to start normally, but pressing the hotkey does nothing.
+
+## Goal
+
+Make hotkey registration failure visible and understandable in the GUI for the current session, using:
+
+1. a startup modal dialog with next steps
+2. a persistent warning in Settings so the failure remains discoverable after startup
+
+## Non-goals
+
+- changing how users edit the hotkey in-app (tracked separately in `#14`)
+- adding retry/rebind UI for the hotkey in this slice
+- persisting hotkey failure state across app restarts
+- redesigning broader startup/onboarding flows
+
+## User experience
+
+### Startup behavior
+
+If hotkey registration fails during `main()`:
+
+- CogStash still starts
+- tray/UI behavior still initializes as today
+- a modal warning is shown once during startup
+
+The modal must clearly say:
+
+- the configured hotkey could not be registered
+- capture by hotkey is unavailable for this session
+- likely next steps:
+  - another app may already be using the shortcut
+  - platform permissions/accessibility hooks may be blocking registration
+  - the user can review the log file for technical detail
+  - the user can change the hotkey in config for now, then restart CogStash
+
+### Persistent warning behavior
+
+When the user opens Settings during the same failed session, the General tab must show a visible warning block near the hotkey section.
+
+That warning must:
+
+- mention that the current hotkey failed to register
+- state that global capture is unavailable until the problem is fixed and the app restarts
+- point the user to the log file
+- remain accurate with current product behavior (do **not** claim hotkey can already be changed inside Settings)
+
+### Session lifetime
+
+- the warning is runtime/session state only
+- if the next app launch registers the hotkey successfully, no warning is shown
+
+## Technical design constraints
+
+- keep the implementation narrow to `ui.app` and `ui.settings`
+- do not add config persistence for this runtime-only failure state
+- prefer a small runtime flag/message passed from `CogStash` app state into Settings rather than a new cross-cutting persistence mechanism
+- keep console/log output in place; GUI feedback is additive, not a replacement
+
+## Acceptance criteria
+
+1. If hotkey registration raises during startup, `main()` shows a warning dialog once.
+2. The app still reaches the normal running state instead of crashing.
+3. Settings General tab shows a persistent warning for the same failed session.
+4. The Settings warning does not falsely imply in-app hotkey editing already exists.
+5. Existing successful-startup behavior remains unchanged when hotkey registration succeeds.
+6. Tests cover:
+   - startup warning shown on hotkey registration failure
+   - startup still completes after failure
+   - Settings warning appears when failure state is present
+   - no warning appears when there is no failure state
+
+## Likely files
+
+- `src/cogstash/ui/app.py`
+- `src/cogstash/ui/settings.py`
+- `tests/ui/test_app.py`
+- `tests/ui/test_settings.py`

--- a/src/cogstash/ui/app.py
+++ b/src/cogstash/ui/app.py
@@ -69,6 +69,20 @@ def _create_log_handler(log_file: Path) -> logging.Handler:
 logger.addHandler(_create_log_handler(LOG_FILE))
 
 
+def _build_hotkey_failure_warning(config: CogStashConfig) -> str:
+    """Build user-facing guidance for a failed global hotkey registration."""
+    return (
+        f"The configured global hotkey failed to register: {config.hotkey}\n\n"
+        "Global capture is unavailable for this session.\n"
+        "Global capture is unavailable until the issue is fixed and CogStash is restarted.\n\n"
+        "Likely causes:\n"
+        "- another app may already be using the shortcut\n"
+        "- platform permissions/accessibility hooks may be blocking registration\n\n"
+        f"See the log file for technical details: {config.log_file}\n"
+        "If needed, change the hotkey in config for now, then restart CogStash."
+    )
+
+
 def platform_font() -> str:
     """Return the native font family for the current OS."""
     fonts = {
@@ -165,6 +179,7 @@ class CogStash:
         self.root = root
         self.config = config
         self.config_path = config_path or get_default_config_path()
+        self.hotkey_warning: str | None = None
         self.queue: queue.Queue[str] = queue.Queue()
         self.is_visible = False
         self.theme = THEMES[config.theme]
@@ -422,6 +437,7 @@ class CogStash:
             self.config,
             self.config_path,
             on_config_changed=self._on_config_changed,
+            hotkey_warning=self.hotkey_warning,
         )
 
     def _on_config_changed(self, config: CogStashConfig) -> None:
@@ -564,8 +580,13 @@ def main():
         listener = keyboard.GlobalHotKeys({config.hotkey: on_hotkey})
         listener.start()
     except Exception:
+        app.hotkey_warning = _build_hotkey_failure_warning(config)
         logger.error("Failed to register global hotkey %s", config.hotkey, exc_info=True)
         safe_print(f"ERROR: Could not register hotkey {config.hotkey}. See {config.log_file} for details.")
+        try:
+            messagebox.showwarning("CogStash Hotkey Warning", app.hotkey_warning)
+        except tk.TclError:
+            pass
         listener = None
 
     try:

--- a/src/cogstash/ui/app.py
+++ b/src/cogstash/ui/app.py
@@ -73,8 +73,8 @@ def _build_hotkey_failure_warning(config: CogStashConfig) -> str:
     """Build user-facing guidance for a failed global hotkey registration."""
     return (
         f"The configured global hotkey failed to register: {config.hotkey}\n\n"
-        "Global capture is unavailable for this session.\n"
-        "Global capture is unavailable until the issue is fixed and CogStash is restarted.\n\n"
+        "Global capture is unavailable for the rest of this session; fix the issue and restart "
+        "CogStash to re-enable it.\n\n"
         "Likely causes:\n"
         "- another app may already be using the shortcut\n"
         "- platform permissions/accessibility hooks may be blocking registration\n\n"

--- a/src/cogstash/ui/settings.py
+++ b/src/cogstash/ui/settings.py
@@ -144,6 +144,31 @@ class SettingsWindow:
                  font=(platform_font(), 10), padx=8, pady=4).pack(anchor="w", padx=(8, 0))
         tk.Label(frame, text="Edit in ~/.cogstash.json to change", bg=t["bg"], fg=t["muted"],
                  font=(platform_font(), 8)).pack(anchor="w", padx=(8, 0), pady=(2, 0))
+        if self.hotkey_warning:
+            warning_frame = tk.Frame(
+                frame,
+                bg=t["entry_bg"],
+                highlightbackground=t["error"],
+                highlightcolor=t["error"],
+                highlightthickness=1,
+            )
+            warning_frame.pack(fill="x", padx=(8, 0), pady=(10, 0))
+            tk.Label(
+                warning_frame,
+                text="⚠ Hotkey Warning",
+                bg=t["entry_bg"],
+                fg=t["error"],
+                font=(platform_font(), 10, "bold"),
+            ).pack(anchor="w", padx=10, pady=(10, 4))
+            tk.Label(
+                warning_frame,
+                text=self.hotkey_warning,
+                bg=t["entry_bg"],
+                fg=t["fg"],
+                justify="left",
+                wraplength=420,
+                font=(platform_font(), 9),
+            ).pack(anchor="w", padx=10, pady=(0, 10))
 
         # Section: Notes File
         tk.Label(frame, text="Notes File", bg=t["bg"], fg=t["fg"],

--- a/src/cogstash/ui/settings.py
+++ b/src/cogstash/ui/settings.py
@@ -64,7 +64,8 @@ class SettingsWindow:
         self.hotkey_warning = hotkey_warning
         self.win = tk.Toplevel(parent)
         self.win.title("CogStash Settings")
-        self.win.geometry("500x450")
+        window_height = 520 if hotkey_warning else 450
+        self.win.geometry(f"500x{window_height}")
         self.win.resizable(False, False)
         self.theme = THEMES[config.theme]
         self.win.configure(bg=self.theme["bg"])

--- a/src/cogstash/ui/settings.py
+++ b/src/cogstash/ui/settings.py
@@ -55,11 +55,13 @@ class SettingsWindow:
         config: CogStashConfig,
         config_path: Path,
         on_config_changed=None,
+        hotkey_warning: str | None = None,
     ):
         self.parent = parent
         self.config = config
         self.config_path = config_path
         self.on_config_changed = on_config_changed
+        self.hotkey_warning = hotkey_warning
         self.win = tk.Toplevel(parent)
         self.win.title("CogStash Settings")
         self.win.geometry("500x450")

--- a/tests/ui/test_app.py
+++ b/tests/ui/test_app.py
@@ -191,7 +191,8 @@ def test_app_main_shows_hotkey_warning_when_registration_fails(monkeypatch, tmp_
         assert len(args) >= 2
         warning_text = args[1]
     assert config.hotkey in warning_text
-    assert "capture is unavailable for this session" in warning_text
+    assert "Global capture is unavailable for the rest of this session; fix the issue and restart CogStash to re-enable it." in warning_text
+    assert "Global capture is unavailable for this session." not in warning_text
     assert str(config.log_file) in warning_text
     assert "another app may already be using the shortcut" in warning_text
     assert "platform permissions/accessibility hooks may be blocking registration" in warning_text
@@ -326,9 +327,11 @@ def test_app_open_settings_receives_runtime_hotkey_warning_after_startup_failure
     assert created_settings[0]["config_path"] == created_apps[0].config_path
     assert created_settings[0]["hotkey_warning"] is not None
     assert "failed to register" in created_settings[0]["hotkey_warning"]
-    assert "Global capture is unavailable until the issue is fixed and CogStash is restarted." in created_settings[0][
-        "hotkey_warning"
-    ]
+    assert (
+        "Global capture is unavailable for the rest of this session; fix the issue and restart CogStash to re-enable it."
+        in created_settings[0]["hotkey_warning"]
+    )
+    assert "Global capture is unavailable for this session." not in created_settings[0]["hotkey_warning"]
     assert str(config.log_file) in created_settings[0]["hotkey_warning"]
     assert config.hotkey in created_settings[0]["hotkey_warning"]
 

--- a/tests/ui/test_app.py
+++ b/tests/ui/test_app.py
@@ -12,6 +12,75 @@ from _helpers import StrictEncodedStream
 from ui._support import needs_display
 
 
+def _run_main_startup(monkeypatch, tmp_path, listener_cls):
+    import types
+
+    import cogstash
+    import cogstash.ui.app as app_mod
+
+    warnings: list[tuple[tuple, dict]] = []
+    created_apps: list[bool] = []
+
+    class FakeRoot:
+        def wait_window(self, _win):
+            raise AssertionError("startup test should not enter wizard flow")
+
+        def mainloop(self):
+            return None
+
+    class FakeApp:
+        def __init__(self, _root, _config):
+            created_apps.append(True)
+            self.queue = object()
+
+    class FakeGuard:
+        def close(self):
+            return None
+
+    config = app_mod.CogStashConfig(
+        output_file=tmp_path / "notes.md",
+        log_file=tmp_path / "cogstash.log",
+        hotkey="<ctrl>+<alt>+space>",
+        last_seen_version=cogstash.__version__,
+        last_seen_installer_version=cogstash.__version__,
+    )
+    capture = StrictEncodedStream("cp1252")
+    windows_mod = types.ModuleType("cogstash.ui.windows")
+    windows_mod.WINDOWS_MUTEX_NAME = "Local\\CogStash.Test"
+    windows_mod.acquire_single_instance = lambda _name: FakeGuard()
+
+    monkeypatch.setattr(app_mod, "load_config", lambda _path: config)
+    monkeypatch.setattr(app_mod, "configure_dpi", lambda: None)
+    monkeypatch.setattr(app_mod.tk, "Tk", lambda: FakeRoot())
+    monkeypatch.setattr(app_mod, "CogStash", FakeApp)
+    monkeypatch.setattr(app_mod, "create_tray_icon", lambda _queue, _config: None)
+    monkeypatch.setattr(app_mod.keyboard, "GlobalHotKeys", listener_cls)
+    monkeypatch.setattr(app_mod.messagebox, "showwarning", lambda *a, **kw: warnings.append((a, kw)))
+    monkeypatch.setattr(
+        app_mod.messagebox,
+        "showinfo",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("startup test should not show duplicate-instance dialog")),
+    )
+    monkeypatch.setitem(sys.modules, "cogstash.ui.windows", windows_mod)
+    monkeypatch.setattr("sys.stdout", capture)
+
+    original_handlers = app_mod.logger.handlers[:]
+    try:
+        app_mod.main()
+    finally:
+        for handler in [h for h in app_mod.logger.handlers[:] if h not in original_handlers]:
+            app_mod.logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+        for handler in original_handlers:
+            if handler not in app_mod.logger.handlers:
+                app_mod.logger.addHandler(handler)
+
+    return config, capture.getvalue(), warnings, created_apps
+
+
 @needs_display
 def test_show_hide_state(tk_root):
     """show_window and hide_window toggle is_visible correctly."""
@@ -101,6 +170,68 @@ def test_app_main_startup_output_is_cp1252_safe(monkeypatch, tmp_path):
     assert "CogStash is running." in output
     assert "Notes" in output
     assert str(config.output_file) in output
+
+
+def test_app_main_shows_hotkey_warning_when_registration_fails(monkeypatch, tmp_path):
+    """Startup should warn the user when the configured global hotkey cannot be registered."""
+
+    class FailingListener:
+        def __init__(self, _mapping):
+            pass
+
+        def start(self):
+            raise OSError("hotkey already in use")
+
+    config, _output, warnings, _created_apps = _run_main_startup(monkeypatch, tmp_path, FailingListener)
+
+    assert len(warnings) == 1
+    args, kwargs = warnings[0]
+    warning_text = kwargs.get("message") if kwargs else None
+    if warning_text is None:
+        assert len(args) >= 2
+        warning_text = args[1]
+    assert config.hotkey in warning_text
+    assert "capture is unavailable for this session" in warning_text
+    assert str(config.log_file) in warning_text
+    assert "another app may already be using the shortcut" in warning_text
+    assert "platform permissions/accessibility hooks may be blocking registration" in warning_text
+    assert "change the hotkey in config for now, then restart CogStash" in warning_text
+
+
+def test_app_main_continues_startup_after_hotkey_registration_failure(monkeypatch, tmp_path):
+    """Startup should still finish after showing the hotkey registration warning."""
+
+    class FailingListener:
+        def __init__(self, _mapping):
+            pass
+
+        def start(self):
+            raise OSError("hotkey already in use")
+
+    _config, output, warnings, created_apps = _run_main_startup(monkeypatch, tmp_path, FailingListener)
+
+    assert len(warnings) == 1
+    assert "CogStash is running." in output
+    assert created_apps == [True]
+
+
+def test_app_main_does_not_show_hotkey_warning_when_registration_succeeds(monkeypatch, tmp_path):
+    """Healthy startup should not show the hotkey failure warning."""
+
+    class FakeListener:
+        def __init__(self, _mapping):
+            self.started = False
+            self.stopped = False
+
+        def start(self):
+            self.started = True
+
+        def stop(self):
+            self.stopped = True
+
+    _config, _output, warnings, _created_apps = _run_main_startup(monkeypatch, tmp_path, FakeListener)
+
+    assert warnings == []
 
 
 def test_app_main_refuses_duplicate_instance_before_startup(monkeypatch, tmp_path):

--- a/tests/ui/test_app.py
+++ b/tests/ui/test_app.py
@@ -40,7 +40,7 @@ def _run_main_startup(monkeypatch, tmp_path, listener_cls):
     config = app_mod.CogStashConfig(
         output_file=tmp_path / "notes.md",
         log_file=tmp_path / "cogstash.log",
-        hotkey="<ctrl>+<alt>+space>",
+        hotkey="<ctrl>+<alt>+space",
         last_seen_version=cogstash.__version__,
         last_seen_installer_version=cogstash.__version__,
     )
@@ -274,7 +274,7 @@ def test_app_open_settings_receives_runtime_hotkey_warning_after_startup_failure
     config = app_mod.CogStashConfig(
         output_file=tmp_path / "notes.md",
         log_file=tmp_path / "cogstash.log",
-        hotkey="<ctrl>+<alt>+space>",
+        hotkey="<ctrl>+<alt>+space",
         last_seen_version=cogstash.__version__,
         last_seen_installer_version=cogstash.__version__,
     )
@@ -300,8 +300,9 @@ def test_app_open_settings_receives_runtime_hotkey_warning_after_startup_failure
         "showinfo",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("startup test should not show duplicate-instance dialog")),
     )
-    monkeypatch.setattr(settings_mod, "SettingsWindow", DummySettingsWindow, raising=False)
+    monkeypatch.setattr(settings_mod, "SettingsWindow", DummySettingsWindow)
     monkeypatch.setitem(sys.modules, "cogstash.ui.windows", windows_mod)
+    monkeypatch.setattr("sys.stdout", StrictEncodedStream("cp1252"))
 
     original_handlers = app_mod.logger.handlers[:]
     try:
@@ -325,6 +326,10 @@ def test_app_open_settings_receives_runtime_hotkey_warning_after_startup_failure
     assert created_settings[0]["config_path"] == created_apps[0].config_path
     assert created_settings[0]["hotkey_warning"] is not None
     assert "failed to register" in created_settings[0]["hotkey_warning"]
+    assert "Global capture is unavailable until the issue is fixed and CogStash is restarted." in created_settings[0][
+        "hotkey_warning"
+    ]
+    assert str(config.log_file) in created_settings[0]["hotkey_warning"]
     assert config.hotkey in created_settings[0]["hotkey_warning"]
 
 

--- a/tests/ui/test_app.py
+++ b/tests/ui/test_app.py
@@ -234,6 +234,100 @@ def test_app_main_does_not_show_hotkey_warning_when_registration_succeeds(monkey
     assert warnings == []
 
 
+@needs_display
+def test_app_open_settings_receives_runtime_hotkey_warning_after_startup_failure(monkeypatch, tk_root, tmp_path):
+    """Opening Settings after a failed startup should receive the session's hotkey warning state."""
+    import types
+
+    import cogstash
+    import cogstash.ui.app as app_mod
+    import cogstash.ui.settings as settings_mod
+
+    created_apps = []
+    created_settings = []
+
+    class FakeGuard:
+        def close(self):
+            return None
+
+    class FailingListener:
+        def __init__(self, _mapping):
+            pass
+
+        def start(self):
+            raise OSError("hotkey already in use")
+
+    class DummySettingsWindow:
+        def __init__(self, parent, config, config_path, on_config_changed=None, hotkey_warning=None):
+            created_settings.append(
+                {
+                    "parent": parent,
+                    "config": config,
+                    "config_path": config_path,
+                    "on_config_changed": on_config_changed,
+                    "hotkey_warning": hotkey_warning,
+                }
+            )
+            self.win = types.SimpleNamespace(winfo_exists=lambda: False)
+
+    real_cogstash = app_mod.CogStash
+    config = app_mod.CogStashConfig(
+        output_file=tmp_path / "notes.md",
+        log_file=tmp_path / "cogstash.log",
+        hotkey="<ctrl>+<alt>+space>",
+        last_seen_version=cogstash.__version__,
+        last_seen_installer_version=cogstash.__version__,
+    )
+    windows_mod = types.ModuleType("cogstash.ui.windows")
+    windows_mod.WINDOWS_MUTEX_NAME = "Local\\CogStash.Test"
+    windows_mod.acquire_single_instance = lambda _name: FakeGuard()
+
+    def capture_app(root, app_config):
+        app = real_cogstash(root, app_config)
+        created_apps.append(app)
+        return app
+
+    monkeypatch.setattr(app_mod, "load_config", lambda _path: config)
+    monkeypatch.setattr(app_mod, "configure_dpi", lambda: None)
+    monkeypatch.setattr(app_mod.tk, "Tk", lambda: tk_root)
+    monkeypatch.setattr(tk_root, "mainloop", lambda: None)
+    monkeypatch.setattr(app_mod, "CogStash", capture_app)
+    monkeypatch.setattr(app_mod, "create_tray_icon", lambda _queue, _config: None)
+    monkeypatch.setattr(app_mod.keyboard, "GlobalHotKeys", FailingListener)
+    monkeypatch.setattr(app_mod.messagebox, "showwarning", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        app_mod.messagebox,
+        "showinfo",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("startup test should not show duplicate-instance dialog")),
+    )
+    monkeypatch.setattr(settings_mod, "SettingsWindow", DummySettingsWindow, raising=False)
+    monkeypatch.setitem(sys.modules, "cogstash.ui.windows", windows_mod)
+
+    original_handlers = app_mod.logger.handlers[:]
+    try:
+        app_mod.main()
+    finally:
+        for handler in [h for h in app_mod.logger.handlers[:] if h not in original_handlers]:
+            app_mod.logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+        for handler in original_handlers:
+            if handler not in app_mod.logger.handlers:
+                app_mod.logger.addHandler(handler)
+
+    assert len(created_apps) == 1
+
+    created_apps[0]._open_settings()
+
+    assert len(created_settings) == 1
+    assert created_settings[0]["config_path"] == created_apps[0].config_path
+    assert created_settings[0]["hotkey_warning"] is not None
+    assert "failed to register" in created_settings[0]["hotkey_warning"]
+    assert config.hotkey in created_settings[0]["hotkey_warning"]
+
+
 def test_app_main_refuses_duplicate_instance_before_startup(monkeypatch, tmp_path):
     """A second GUI launch should stop before creating another root/tray instance."""
     import types

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -10,6 +10,15 @@ import pytest
 from ui._support import needs_display
 
 
+def _collect_label_text(widget):
+    texts = []
+    for child in widget.winfo_children():
+        if child.winfo_class() == "Label":
+            texts.append(child.cget("text"))
+        texts.extend(_collect_label_text(child))
+    return texts
+
+
 @needs_display
 def test_settings_window_has_tabs(tk_root, tmp_path):
     """Settings window creates 4 tabs."""
@@ -19,6 +28,49 @@ def test_settings_window_has_tabs(tk_root, tmp_path):
     sw = SettingsWindow(tk_root, CogStashConfig(), tmp_path / "test.json")
     assert hasattr(sw, "tab_buttons")
     assert len(sw.tab_buttons) == 4
+    sw.win.destroy()
+
+
+@needs_display
+def test_settings_shows_hotkey_warning_when_registration_failed(tk_root, tmp_path):
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
+
+    log_file = tmp_path / "cogstash.log"
+    warning_text = (
+        "Hotkey failed to register: <ctrl>+<shift>+<space>\n"
+        "Global capture is unavailable until the issue is fixed and CogStash is restarted.\n"
+        f"See the log file for details: {log_file}"
+    )
+
+    sw = SettingsWindow(
+        tk_root,
+        CogStashConfig(log_file=log_file),
+        tmp_path / "test.json",
+        hotkey_warning=warning_text,
+    )
+    labels = _collect_label_text(sw.tab_frames[0])
+    all_text = "\n".join(labels)
+
+    assert "Hotkey failed to register" in all_text
+    assert "Global capture is unavailable until the issue is fixed and CogStash is restarted." in all_text
+    assert str(log_file) in all_text
+    assert "change the hotkey in Settings" not in all_text
+    assert "edit the hotkey in Settings" not in all_text
+
+    sw.win.destroy()
+
+
+@needs_display
+def test_settings_hides_hotkey_warning_when_session_is_healthy(tk_root, tmp_path):
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
+
+    sw = SettingsWindow(tk_root, CogStashConfig(), tmp_path / "test.json")
+    labels = _collect_label_text(sw.tab_frames[0])
+
+    assert not any("failed to register" in text for text in labels)
+
     sw.win.destroy()
 
 

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -49,9 +49,11 @@ def test_settings_shows_hotkey_warning_when_registration_failed(tk_root, tmp_pat
         tmp_path / "test.json",
         hotkey_warning=warning_text,
     )
+    sw.win.update_idletasks()
     labels = _collect_label_text(sw.tab_frames[0])
     all_text = "\n".join(labels)
 
+    assert sw.win.winfo_height() > 450
     assert "Hotkey failed to register" in all_text
     assert "Global capture is unavailable until the issue is fixed and CogStash is restarted." in all_text
     assert str(log_file) in all_text

--- a/tests/ui/test_settings_extended.py
+++ b/tests/ui/test_settings_extended.py
@@ -286,11 +286,12 @@ def test_app_open_settings_uses_shared_config_path(tk_root, tmp_path):
     created = []
 
     class DummySettingsWindow:
-        def __init__(self, parent, config, passed_config_path, on_config_changed=None):
-            created.append((parent, config, passed_config_path, on_config_changed))
+        def __init__(self, parent, config, passed_config_path, on_config_changed=None, hotkey_warning=None):
+            created.append((parent, config, passed_config_path, on_config_changed, hotkey_warning))
             self.win = None
 
     with patch("cogstash.ui.settings.SettingsWindow", DummySettingsWindow):
         app._open_settings()
 
     assert created[0][2] == config_path
+    assert created[0][4] is None


### PR DESCRIPTION
## Summary
- surface a startup warning when global hotkey registration fails while keeping CogStash running
- carry the session-only warning into Settings -> General and show a persistent warning block there
- add spec/plan docs plus focused regression coverage for the failure and healthy paths

## Verification
- uv run pytest tests\ -q
- uv run ruff check src\ tests\
- uv run mypy src\cogstash\

Closes #15