### PR TITLE
docs: improve CLI help and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,9 @@ echo "Follow up with portable users" | cogstash add
 
 ### `cogstash edit`
 
-Edit a note by note number, or resolve it from a search query.
+Edit a note's text.
+
+Use a note number or `--search` to target the note. When using `--search`, the replacement text follows the search term.
 
 ```bash
 cogstash edit 42 "Updated note text"
@@ -224,7 +226,9 @@ cogstash edit --search "installer" "Updated note text"
 
 ### `cogstash delete`
 
-Delete a note by note number or search query.
+Delete a note.
+
+Use a note number or `--search` to target the note. The command asks for confirmation unless `--yes` is provided.
 
 ```bash
 cogstash delete 42
@@ -251,13 +255,22 @@ cogstash stats
 
 ### `cogstash config`
 
-Launch the interactive config wizard, or read/write individual supported keys.
+View configuration values, update supported keys, or launch the interactive wizard.
+
+`cogstash config` with no action starts the interactive wizard. Press Enter to keep current value.
 
 ```bash
 cogstash config
 cogstash config get theme
 cogstash config set window_size wide
 ```
+
+> **Note:** `cogstash config get` supports `hotkey`, `theme`, `window_size`,
+> `output_file`, `log_file`, and `tags`. `cogstash config set` supports
+> `hotkey`, `theme`, `window_size`, `output_file`, and `log_file`. Tags are
+> not writable via `config set`.
+>
+> Internal bookkeeping keys are not exposed through this command.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-12-cli-help-examples.md
+++ b/docs/superpowers/plans/2026-04-12-cli-help-examples.md
@@ -1,0 +1,280 @@
+# CLI Help Text and Examples Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `edit`, `delete`, and `config` help output self-sufficient with concrete examples and clear mode guidance, then align the README examples with that help.
+
+**Architecture:** Keep this as a parser/help-text-only change in `src/cogstash/cli/main.py`, with regression coverage in `tests/cli/test_cli.py`. Do not change runtime command semantics. After the parser help is locked by tests, update the README examples for the same commands so the CLI and docs stay in sync.
+
+**Tech Stack:** Python 3.9+, argparse, pytest, README markdown
+
+---
+
+## File / Artifact Map
+
+- Modify: `src/cogstash/cli/main.py`
+  - enrich subparser help for `edit`, `delete`, and `config`
+  - add command descriptions / examples / restrictions without changing command behavior
+- Modify: `tests/cli/test_cli.py`
+  - add focused parser help tests for `edit`, `delete`, and `config`
+- Modify: `README.md`
+  - align examples and wording for `edit`, `delete`, and `config`
+- Reference: `docs/superpowers/specs/2026-04-12-cli-help-examples.md`
+  - scope, behavior, and acceptance criteria for issue `#16`
+
+## Baseline Verification
+
+Before implementation starts, run:
+
+```bash
+uv run pytest tests\cli\test_cli.py -v
+```
+
+Expected: PASS on the current branch before any new tests are added, so later failures can be attributed to the new red tests rather than unrelated baseline breakage.
+
+## Task 1: Lock `edit` and `delete` help expectations with failing tests
+
+**Files:**
+- Modify: `tests/cli/test_cli.py`
+- Modify: `src/cogstash/cli/main.py`
+
+- [ ] **Step 1: Write failing `edit --help` and `delete --help` tests**
+
+Add focused tests in `tests/cli/test_cli.py` that call `build_parser()` and capture `parser.parse_args([...,"--help"])` output.
+
+```python
+def test_edit_help_includes_examples_and_search_guidance(capsys):
+    from cogstash.cli import build_parser
+
+    parser = build_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["edit", "--help"])
+
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "note number or --search" in out
+    assert "cogstash edit 42 \"Updated note text\"" in out
+    assert "cogstash edit --search \"installer\" \"Updated note text\"" in out
+
+
+def test_delete_help_includes_confirmation_and_examples(capsys):
+    from cogstash.cli import build_parser
+
+    parser = build_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["delete", "--help"])
+
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "--yes" in out
+    assert "cogstash delete 42" in out
+    assert "cogstash delete --search \"installer\" --yes" in out
+```
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests\cli\test_cli.py -k "edit_help or delete_help" -v
+```
+
+Expected: FAIL because the current subparser help output does not yet include these examples or guidance.
+
+- [ ] **Step 3: Implement the minimal parser help improvements for `edit` and `delete`**
+
+Update `src/cogstash/cli/main.py` so the `edit` and `delete` subparsers use richer help text. Use `description=` and `epilog=` (with an `argparse` formatter that preserves examples cleanly) rather than changing command behavior.
+
+Minimum target shape:
+
+```python
+p_edit = sub.add_parser(
+    "edit",
+    help="Edit a note by number or search",
+    description="Edit an existing note by number or with --search.",
+    epilog=(
+        "Examples:\n"
+        "  cogstash edit 42 \"Updated note text\"\n"
+        "  cogstash edit --search \"installer\" \"Updated note text\""
+    ),
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+)
+```
+
+Apply the same pattern to `delete`, including wording about confirmation and `--yes`.
+
+- [ ] **Step 4: Re-run the focused tests to verify they pass**
+
+Run:
+
+```bash
+uv run pytest tests\cli\test_cli.py -k "edit_help or delete_help" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the parser help changes for `edit` and `delete`**
+
+```bash
+git add tests/cli/test_cli.py src/cogstash/cli/main.py
+git commit -m "feat: improve edit and delete CLI help"
+```
+
+## Task 2: Lock `config --help` wizard and restriction guidance with failing tests
+
+**Files:**
+- Modify: `tests/cli/test_cli.py`
+- Modify: `src/cogstash/cli/main.py`
+
+- [ ] **Step 1: Write a failing `config --help` test**
+
+Add a focused test in `tests/cli/test_cli.py` that verifies `config --help` documents the command modes and key restrictions.
+
+```python
+def test_config_help_includes_wizard_examples_and_key_restrictions(capsys):
+    from cogstash.cli import build_parser
+
+    parser = build_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["config", "--help"])
+
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "omit action to open the wizard" in out
+    assert "cogstash config" in out
+    assert "cogstash config get theme" in out
+    assert "cogstash config set window_size wide" in out
+    assert "tags" in out
+    assert "get-only" in out
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+uv run pytest tests\cli\test_cli.py -k "config_help" -v
+```
+
+Expected: FAIL because the current `config` help output does not yet explain wizard mode or the key restrictions.
+
+- [ ] **Step 3: Implement the minimal `config` help improvements**
+
+Update the `config` subparser in `src/cogstash/cli/main.py` so its help text documents:
+
+1. default wizard mode when no action is provided
+2. `get` and `set` examples
+3. supported CLI-facing keys
+4. that `tags` is readable but not writable via `config set`
+5. that internal keys are not exposed through this command
+
+Keep the current command behavior untouched.
+Prefer deriving key lists from existing constants/helpers in `src/cogstash/cli/main.py` rather than duplicating them in multiple strings where practical.
+
+- [ ] **Step 4: Re-run the focused test to verify it passes**
+
+Run:
+
+```bash
+uv run pytest tests\cli\test_cli.py -k "config_help" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the `config` help update**
+
+```bash
+git add tests/cli/test_cli.py src/cogstash/cli/main.py
+git commit -m "feat: improve config CLI help"
+```
+
+## Task 3: Align README examples with the improved CLI help
+
+**Files:**
+- Modify: `README.md`
+- Reference: `src/cogstash/cli/main.py`
+
+- [ ] **Step 1: Update the README command examples**
+
+Refresh the README sections for:
+
+- `cogstash edit`
+- `cogstash delete`
+- `cogstash config`
+
+Make sure they match the help output language and examples introduced in Tasks 1 and 2. Keep the docs limited to this issue’s scope.
+
+- [ ] **Step 2: Manually verify README alignment against CLI help**
+
+Check that the README examples match the parser help strings for the same commands and do not claim unsupported behavior.
+
+- [ ] **Step 3: Run the focused CLI help tests again**
+
+Run:
+
+```bash
+uv run pytest tests\cli\test_cli.py -k "edit_help or delete_help or config_help" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the README alignment**
+
+```bash
+git add README.md
+git commit -m "docs: align CLI help examples"
+```
+
+## Task 4: Run full verification and prepare the branch for review
+
+**Files:**
+- Modify: none
+- Verify: `src/cogstash/cli/main.py`
+- Verify: `tests/cli/test_cli.py`
+- Verify: `README.md`
+
+- [ ] **Step 1: Run targeted CLI tests**
+
+Run:
+
+```bash
+uv run pytest tests\cli\test_cli.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full repo verification**
+
+Run:
+
+```bash
+uv run pytest tests\ -q
+uv run ruff check src\ tests\
+uv run mypy src\cogstash\
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Review the diff for accidental scope creep**
+
+Confirm only the intended files changed:
+
+- `src/cogstash/cli/main.py`
+- `tests/cli/test_cli.py`
+- `README.md`
+
+- [ ] **Step 4: Create the implementation branch commit set**
+
+Expected commit boundaries:
+
+1. `feat: improve edit and delete CLI help`
+2. `feat: improve config CLI help`
+3. `docs: align CLI help examples`
+
+- [ ] **Step 5: Open PR and update issue `#16`**
+
+PR summary should call out:
+
+1. richer help output for `edit`, `delete`, and `config`
+2. wizard-mode and config-key restriction guidance
+3. README alignment for those examples

--- a/docs/superpowers/specs/2026-04-12-cli-help-examples.md
+++ b/docs/superpowers/specs/2026-04-12-cli-help-examples.md
@@ -1,0 +1,73 @@
+# CLI Help Text and Examples Spec
+
+**Issue:** `#16` Improve CLI help text and examples for complex commands
+
+**Problem**
+
+CogStash CLI help is functional but too terse for commands with multiple usage modes. In particular, `edit`, `delete`, and `config` do not explain their branching behavior clearly enough in `--help`, which makes the CLI harder to discover without reading the README or source.
+
+**Goal**
+
+Make `cogstash edit --help`, `cogstash delete --help`, and `cogstash config --help` self-sufficient enough that a user can understand the command modes and copy a working example directly from the CLI.
+
+## In Scope
+
+1. Improve the built-in `argparse` help output for:
+   - `cogstash edit`
+   - `cogstash delete`
+   - `cogstash config`
+2. Add practical examples to those help surfaces.
+3. Clarify positional versus `--search` usage for `edit` and `delete`.
+4. Clarify `config` wizard mode, `get` / `set` usage, and key restrictions.
+5. Refresh the matching README command examples so the docs stay aligned with the CLI help text.
+
+## Out of Scope
+
+1. Adding new CLI commands or flags.
+2. Changing command behavior, parsing rules, or config semantics.
+3. Refreshing help text for every subcommand.
+4. Reworking README sections unrelated to the chosen commands.
+
+## Behavior Decisions
+
+### `edit --help`
+
+- Must explain the two supported targeting modes:
+  - note number as the first positional token
+  - `--search` / `-s` keyword targeting
+- Must include at least one example of each mode.
+- Must make it clear that replacement text follows the selected note target.
+
+### `delete --help`
+
+- Must explain the two supported targeting modes:
+  - positional note number
+  - `--search` / `-s` keyword targeting
+- Must mention confirmation behavior and `--yes`.
+- Must include at least one example of number-based deletion and one search-based deletion.
+
+### `config --help`
+
+- Must explain that running `cogstash config` with no action starts the interactive wizard.
+- Must include examples for:
+  - wizard/default mode
+  - `config get`
+  - `config set`
+- Must document that:
+  - `tags` is readable via `config get` but not writable via `config set`
+  - internal/non-CLI config keys are not supported through the command
+
+## UX Constraints
+
+- Keep help text concise enough to stay readable in a terminal.
+- Favor examples over long prose.
+- Do not promise behavior the CLI does not support today.
+- Keep wording aligned with current command behavior and current README examples.
+
+## Acceptance Criteria
+
+1. Focused CLI tests assert the help output for `edit`, `delete`, and `config` includes the new examples and guidance.
+2. Those tests fail before implementation and pass after implementation.
+3. CLI behavior remains unchanged aside from help output.
+4. README examples for `edit`, `delete`, and `config` match the intended help guidance.
+5. The final verification for the implementation can rely on existing project commands only.

--- a/src/cogstash/cli/main.py
+++ b/src/cogstash/cli/main.py
@@ -36,14 +36,11 @@ from .formatting import (
 VALID_CONFIG_KEYS = {"hotkey", "theme", "window_size", "output_file", "log_file", "tags"}
 
 
-class _HelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
+class _MultilineHelpFormatter(argparse.RawDescriptionHelpFormatter):
     def _split_lines(self, text: str, width: int) -> list[str]:
         if "\n" in text:
             return text.splitlines()
         return argparse.HelpFormatter._split_lines(self, text, width)
-
-    def _fill_text(self, text: str, width: int, indent: str) -> str:
-        return "\n".join(f"{indent}{line}" for line in text.splitlines())
 
 
 def _output_file(config: CogStashConfig) -> Path:
@@ -475,7 +472,6 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="cogstash",
         description="CogStash — query your brain dump from the terminal.",
-        formatter_class=_HelpFormatter,
     )
     parser.add_argument("--version", "-V", action="version", version=f"cogstash {package_version}")
     sub = parser.add_subparsers(dest="command")
@@ -509,7 +505,7 @@ def build_parser() -> argparse.ArgumentParser:
             '  cogstash edit 42 "Updated note text"\n'
             '  cogstash edit --search "installer" "Updated note text"'
         ),
-        formatter_class=_HelpFormatter,
+        formatter_class=_MultilineHelpFormatter,
     )
     p_edit.add_argument("args", nargs="*", help="Note number followed by new text")
     p_edit.add_argument("--search", "-s", help="Find note by keyword instead of number")
@@ -528,7 +524,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  cogstash delete 42\n"
             '  cogstash delete --search "installer" --yes'
         ),
-        formatter_class=_HelpFormatter,
+        formatter_class=_MultilineHelpFormatter,
     )
     p_delete.add_argument("number", type=int, nargs="?", default=None, help="Note number")
     p_delete.add_argument("--search", "-s", help="Find note by keyword")

--- a/src/cogstash/cli/main.py
+++ b/src/cogstash/cli/main.py
@@ -36,6 +36,16 @@ from .formatting import (
 VALID_CONFIG_KEYS = {"hotkey", "theme", "window_size", "output_file", "log_file", "tags"}
 
 
+class _HelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
+    def _split_lines(self, text: str, width: int) -> list[str]:
+        if "\n" in text:
+            return text.splitlines()
+        return argparse.HelpFormatter._split_lines(self, text, width)
+
+    def _fill_text(self, text: str, width: int, indent: str) -> str:
+        return "\n".join(f"{indent}{line}" for line in text.splitlines())
+
+
 def _output_file(config: CogStashConfig) -> Path:
     output_file = config.output_file
     assert output_file is not None, "output_file should be set by CogStashConfig"
@@ -462,7 +472,11 @@ def build_parser() -> argparse.ArgumentParser:
     except PackageNotFoundError:
         package_version = "0.0.0-unknown"
 
-    parser = argparse.ArgumentParser(prog="cogstash", description="CogStash — query your brain dump from the terminal.")
+    parser = argparse.ArgumentParser(
+        prog="cogstash",
+        description="CogStash — query your brain dump from the terminal.",
+        formatter_class=_HelpFormatter,
+    )
     parser.add_argument("--version", "-V", action="version", version=f"cogstash {package_version}")
     sub = parser.add_subparsers(dest="command")
 
@@ -482,12 +496,40 @@ def build_parser() -> argparse.ArgumentParser:
     p_add.add_argument("text", nargs="*", help="Note text (or pipe via stdin)")
     p_add.set_defaults(func=cmd_add)
 
-    p_edit = sub.add_parser("edit", help="Edit a note's text")
+    p_edit = sub.add_parser(
+        "edit",
+        help="Edit a note's text",
+        description=(
+            "Edit a note's text.\n\n"
+            "Use a note number or --search to target the note.\n"
+            "When using --search, the replacement text follows the search term."
+        ),
+        epilog=(
+            "Examples:\n"
+            '  cogstash edit 42 "Updated note text"\n'
+            '  cogstash edit --search "installer" "Updated note text"'
+        ),
+        formatter_class=_HelpFormatter,
+    )
     p_edit.add_argument("args", nargs="*", help="Note number followed by new text")
     p_edit.add_argument("--search", "-s", help="Find note by keyword instead of number")
     p_edit.set_defaults(func=cmd_edit)
 
-    p_delete = sub.add_parser("delete", help="Delete a note")
+    p_delete = sub.add_parser(
+        "delete",
+        help="Delete a note",
+        description=(
+            "Delete a note.\n\n"
+            "Use a note number or --search to target the note.\n"
+            "The command asks for confirmation unless --yes is provided."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  cogstash delete 42\n"
+            '  cogstash delete --search "installer" --yes'
+        ),
+        formatter_class=_HelpFormatter,
+    )
     p_delete.add_argument("number", type=int, nargs="?", default=None, help="Note number")
     p_delete.add_argument("--search", "-s", help="Find note by keyword")
     p_delete.add_argument("--yes", "-y", action="store_true", help="Skip confirmation")

--- a/src/cogstash/cli/main.py
+++ b/src/cogstash/cli/main.py
@@ -34,6 +34,8 @@ from .formatting import (
 )
 
 VALID_CONFIG_KEYS = {"hotkey", "theme", "window_size", "output_file", "log_file", "tags"}
+CONFIG_GET_KEYS = tuple(sorted(VALID_CONFIG_KEYS))
+CONFIG_SET_KEYS = tuple(key for key in CONFIG_GET_KEYS if key != "tags")
 
 
 class _MultilineHelpFormatter(argparse.RawDescriptionHelpFormatter):
@@ -539,7 +541,26 @@ def build_parser() -> argparse.ArgumentParser:
     p_stats = sub.add_parser("stats", help="Show note statistics")
     p_stats.set_defaults(func=cmd_stats)
 
-    p_config = sub.add_parser("config", help="View or set configuration")
+    p_config = sub.add_parser(
+        "config",
+        help="View or set configuration",
+        description=(
+            "View configuration values, update supported keys, or launch the interactive wizard.\n\n"
+            "CogStash config with no action starts the interactive wizard.\n"
+            "Press Enter to keep current value.\n"
+            f"Readable keys: {', '.join(CONFIG_GET_KEYS)}\n"
+            f"Writable via config set: {', '.join(CONFIG_SET_KEYS)}\n"
+            "Tags are not writable via config set.\n"
+            "Internal bookkeeping keys are not exposed through this command."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  cogstash config\n"
+            "  cogstash config get theme\n"
+            "  cogstash config set window_size wide"
+        ),
+        formatter_class=_MultilineHelpFormatter,
+    )
     p_config.add_argument("action", nargs="?", choices=["get", "set"], default=None, help="Action: get or set (omit for wizard)")
     p_config.add_argument("key", nargs="?", help="Config key")
     p_config.add_argument("value", nargs="?", help="New value (for set)")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -854,7 +854,7 @@ def test_config_help_includes_wizard_examples_and_restrictions(capsys):
     assert re.search(r"(?m)^\s*cogstash config\s*$", output)
     assert "cogstash config get theme" in output
     assert "cogstash config set window_size wide" in output
-    assert "tags" in lowered and ("get-only" in lowered or "read-only" in lowered or "not writable" in lowered)
+    assert "tags are not writable via config set" in lowered
     assert "launch_at_startup" not in output
     assert "last_seen_version" not in output
     assert "last_seen_installer_version" not in output

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -894,7 +894,6 @@ def test_delete_help_includes_yes_and_examples(capsys):
 
     output = capsys.readouterr().out
     assert exc.value.code == 0
-    assert "--yes" in output
     assert 'cogstash delete 42' in output
     assert 'cogstash delete --search "installer" --yes' in output
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -832,6 +832,32 @@ def test_cmd_config_get_invalid_key(tmp_path, capsys):
         )
 
 
+def test_config_help_includes_wizard_examples_and_restrictions(capsys):
+    """config help documents wizard mode, examples, and key restrictions."""
+    import pytest
+
+    from cogstash.cli import build_parser
+
+    parser = build_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["config", "--help"])
+
+    output = capsys.readouterr().out
+    lowered = output.lower()
+
+    assert exc.value.code == 0
+    assert "wizard" in lowered
+    assert "no action" in lowered or "omit for wizard" in lowered
+    assert "examples:" in lowered
+    assert "cogstash config" in output
+    assert "cogstash config get theme" in output
+    assert "cogstash config set window_size wide" in output
+    assert "tags" in lowered and ("get-only" in lowered or "read-only" in lowered or "not writable" in lowered)
+    assert "output_file" not in output
+    assert "log_file" not in output
+    assert "hotkey" not in output
+
+
 def test_version_flag(capsys):
     """cogstash --version prints the version string."""
     from cogstash.cli import build_parser

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -834,6 +834,8 @@ def test_cmd_config_get_invalid_key(tmp_path, capsys):
 
 def test_config_help_includes_wizard_examples_and_restrictions(capsys):
     """config help documents wizard mode, examples, and key restrictions."""
+    import re
+
     import pytest
 
     from cogstash.cli import build_parser
@@ -846,12 +848,10 @@ def test_config_help_includes_wizard_examples_and_restrictions(capsys):
     lowered = output.lower()
 
     assert exc.value.code == 0
-    assert "wizard" in lowered
-    assert "interactive wizard" in lowered
+    assert "cogstash config with no action starts the interactive wizard" in lowered
     assert "press enter to keep current value" in lowered
-    assert "no action" in lowered or "omit for wizard" in lowered
     assert "examples:" in lowered
-    assert "cogstash config" in output
+    assert re.search(r"(?m)^\s*cogstash config\s*$", output)
     assert "cogstash config get theme" in output
     assert "cogstash config set window_size wide" in output
     assert "tags" in lowered and ("get-only" in lowered or "read-only" in lowered or "not writable" in lowered)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -847,6 +847,8 @@ def test_config_help_includes_wizard_examples_and_restrictions(capsys):
 
     assert exc.value.code == 0
     assert "wizard" in lowered
+    assert "interactive wizard" in lowered
+    assert "press enter to keep current value" in lowered
     assert "no action" in lowered or "omit for wizard" in lowered
     assert "examples:" in lowered
     assert "cogstash config" in output
@@ -855,7 +857,6 @@ def test_config_help_includes_wizard_examples_and_restrictions(capsys):
     assert "tags" in lowered and ("get-only" in lowered or "read-only" in lowered or "not writable" in lowered)
     assert "output_file" not in output
     assert "log_file" not in output
-    assert "hotkey" not in output
 
 
 def test_version_flag(capsys):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -880,6 +880,7 @@ def test_edit_help_includes_note_number_and_search_examples(capsys):
     assert "note number or --search" in output.lower()
     assert 'cogstash edit 42 "Updated note text"' in output
     assert 'cogstash edit --search "installer" "Updated note text"' in output
+    assert "(default:" not in output
 
 
 def test_delete_help_includes_yes_and_examples(capsys):
@@ -896,6 +897,7 @@ def test_delete_help_includes_yes_and_examples(capsys):
     assert exc.value.code == 0
     assert 'cogstash delete 42' in output
     assert 'cogstash delete --search "installer" --yes' in output
+    assert "(default:" not in output
 
 
 def test_cli_main_version_does_not_import_app(monkeypatch):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -872,12 +872,12 @@ def test_edit_help_includes_note_number_and_search_examples(capsys):
     from cogstash.cli import build_parser
 
     parser = build_parser()
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as exc:
         parser.parse_args(["edit", "--help"])
 
     output = capsys.readouterr().out
-    assert "note number" in output.lower()
-    assert "--search" in output
+    assert exc.value.code == 0
+    assert "note number or --search" in output.lower()
     assert 'cogstash edit 42 "Updated note text"' in output
     assert 'cogstash edit --search "installer" "Updated note text"' in output
 
@@ -889,10 +889,11 @@ def test_delete_help_includes_yes_and_examples(capsys):
     from cogstash.cli import build_parser
 
     parser = build_parser()
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as exc:
         parser.parse_args(["delete", "--help"])
 
     output = capsys.readouterr().out
+    assert exc.value.code == 0
     assert "--yes" in output
     assert 'cogstash delete 42' in output
     assert 'cogstash delete --search "installer" --yes' in output

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -865,6 +865,39 @@ def test_version_flag_without_isatty(monkeypatch):
     assert "cogstash" in output.lower()
 
 
+def test_edit_help_includes_note_number_and_search_examples(capsys):
+    """edit help teaches note-number and search-based editing."""
+    import pytest
+
+    from cogstash.cli import build_parser
+
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["edit", "--help"])
+
+    output = capsys.readouterr().out
+    assert "note number" in output.lower()
+    assert "--search" in output
+    assert 'cogstash edit 42 "Updated note text"' in output
+    assert 'cogstash edit --search "installer" "Updated note text"' in output
+
+
+def test_delete_help_includes_yes_and_examples(capsys):
+    """delete help teaches confirmation and search-based deletion."""
+    import pytest
+
+    from cogstash.cli import build_parser
+
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["delete", "--help"])
+
+    output = capsys.readouterr().out
+    assert "--yes" in output
+    assert 'cogstash delete 42' in output
+    assert 'cogstash delete --search "installer" --yes' in output
+
+
 def test_cli_main_version_does_not_import_app(monkeypatch):
     """cli_main --version should exit cleanly without importing GUI/app dependencies."""
     import sys

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -855,8 +855,9 @@ def test_config_help_includes_wizard_examples_and_restrictions(capsys):
     assert "cogstash config get theme" in output
     assert "cogstash config set window_size wide" in output
     assert "tags" in lowered and ("get-only" in lowered or "read-only" in lowered or "not writable" in lowered)
-    assert "output_file" not in output
-    assert "log_file" not in output
+    assert "launch_at_startup" not in output
+    assert "last_seen_version" not in output
+    assert "last_seen_installer_version" not in output
 
 
 def test_version_flag(capsys):


### PR DESCRIPTION
## Summary
- improve `edit` and `delete` help with clearer targeting guidance and concrete examples
- improve `config --help` with wizard-mode guidance, examples, and config-surface restrictions
- align the README examples for `edit`, `delete`, and `config` with the updated CLI help

## Verification
- uv run pytest tests\ -q
- uv run ruff check src\ tests\
- uv run mypy src\cogstash\

Closes #16