### PR TITLE
feat: improve browse filter clarity

### DIFF
--- a/docs/superpowers/plans/2026-04-12-browse-filter-clarity.md
+++ b/docs/superpowers/plans/2026-04-12-browse-filter-clarity.md
@@ -1,0 +1,317 @@
+# Browse Filter Clarity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Browse filter state obvious with a compact active-filters summary bar, one clear-all action, and a filter-aware empty state.
+
+**Architecture:** Keep this change localized to `src/cogstash/ui/browse.py` and existing Browse UI tests. The implementation should add lightweight UI elements on top of the current search + tag filtering flow without changing the underlying filter semantics. The clear-all action should reuse the existing state variables (`search_var`, `_active_tag`) and the existing `_apply_filters()` flow rather than introducing a new filter model.
+
+**Tech Stack:** Python 3.9+, tkinter, pytest
+
+---
+
+## File / Artifact Map
+
+- Modify: `src/cogstash/ui/browse.py`
+  - add active-filter summary UI
+  - add one clear-all action
+  - add filter-aware empty state inside the cards area
+- Modify: `tests/ui/test_browse.py`
+  - add focused Browse filter-clarity tests for the new UI/state behavior
+- Reference: `docs/superpowers/specs/2026-04-12-browse-filter-clarity.md`
+  - approved scope and UX contract for issue `#18`
+
+## Baseline Verification
+
+Before implementation starts, run:
+
+```bash
+uv run pytest tests\ui\test_browse.py -v
+```
+
+Expected: PASS on the current branch before any new tests are added.
+
+## Task 1: Lock active-filter summary behavior with failing tests
+
+**Files:**
+- Modify: `tests/ui/test_browse.py`
+- Modify later: `src/cogstash/ui/browse.py`
+
+- [ ] **Step 1: Write a failing test for hidden summary state when no filters are active**
+
+Add a test that opens Browse with multiple notes and asserts the new summary row is absent or hidden before filters are applied.
+
+```python
+@needs_display
+def test_browse_hides_filter_summary_when_unfiltered(tmp_path, tk_root):
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
+
+    notes = tmp_path / "cogstash.md"
+    notes.write_text(
+        "- [2026-03-26 14:30] buy milk #todo\n"
+        "- [2026-03-26 11:20] meeting notes #work\n",
+        encoding="utf-8",
+    )
+
+    win = BrowseWindow(tk_root, CogStashConfig(output_file=notes))
+
+    assert win._filter_summary_frame is None or not win._filter_summary_frame.winfo_ismapped()
+
+    win.window.destroy()
+```
+
+- [ ] **Step 2: Write a failing test for combined search + tag summary text**
+
+Add a test that applies both a search query and tag filter, then asserts the summary bar is visible and includes both the search and tag state.
+
+```python
+@needs_display
+def test_browse_shows_combined_filter_summary(tmp_path, tk_root):
+    ...
+    win.search_var.set("install")
+    win._on_tag_filter("todo")
+    win._on_search()
+
+    assert win._filter_summary_label is not None
+    summary = win._filter_summary_label.cget("text")
+    assert 'Search: "install"' in summary
+    assert "Tag: todo" in summary
+```
+
+- [ ] **Step 3: Write failing tests for search-only and tag-only summary states**
+
+Add one focused test for each single-filter state so the implementation cannot skip either case:
+
+1. search-only active summary text
+2. tag-only active summary text
+
+Both tests should assert the summary bar is visible and only mentions the active filter type for that scenario.
+
+- [ ] **Step 4: Write a failing test for clear-all behavior**
+
+Add a test that activates both filters, invokes the new clear action, and asserts:
+
+1. `search_var` becomes empty
+2. `_active_tag` becomes `None`
+3. full note list returns
+
+- [ ] **Step 5: Run the focused tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests\ui\test_browse.py -k "filter_summary or clear_filters" -v
+```
+
+Expected: FAIL because the summary/clear-all UI does not exist yet.
+
+- [ ] **Step 6: Commit the red tests**
+
+```bash
+git add tests/ui/test_browse.py
+git commit -m "test: lock browse filter summary UX"
+```
+
+## Task 2: Implement the summary bar and clear-all action
+
+**Files:**
+- Modify: `src/cogstash/ui/browse.py`
+- Existing tests: `tests/ui/test_browse.py`
+
+- [ ] **Step 1: Add minimal UI state for the summary bar**
+
+In `BrowseWindow`, add focused instance attributes for the new UI:
+
+- summary frame
+- summary label
+- clear-filters button
+
+Prefer explicit attributes like:
+
+```python
+self._filter_summary_frame: tk.Frame | None = None
+self._filter_summary_label: tk.Label | None = None
+self._clear_filters_button: tk.Button | None = None
+```
+
+- [ ] **Step 2: Add a helper that builds/updates the summary bar**
+
+Add a helper with one responsibility, for example:
+
+```python
+def _update_filter_summary(self) -> None:
+    ...
+```
+
+It should:
+
+1. hide the summary UI when no filters are active
+2. show the summary UI when search/tag filters are active
+3. render combined summary text when both are active
+
+- [ ] **Step 3: Add one clear-all action**
+
+Add a helper such as:
+
+```python
+def _clear_filters(self) -> None:
+    self.search_var.set("")
+    self._active_tag = None
+    self._update_pill_styles()
+    self._apply_filters()
+```
+
+Keep it small and reuse the existing filter pipeline.
+
+- [ ] **Step 4: Call the summary update from the existing filter flow**
+
+Update `_apply_filters()` so it refreshes the summary state before rendering cards.
+
+- [ ] **Step 5: Run the focused tests to verify they pass**
+
+Run:
+
+```bash
+uv run pytest tests\ui\test_browse.py -k "filter_summary or clear_filters" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the summary-bar implementation**
+
+```bash
+git add src/cogstash/ui/browse.py tests/ui/test_browse.py
+git commit -m "feat: clarify active browse filters"
+```
+
+## Task 3: Lock filtered empty-state behavior with failing tests
+
+**Files:**
+- Modify: `tests/ui/test_browse.py`
+- Modify later: `src/cogstash/ui/browse.py`
+
+- [ ] **Step 1: Write a failing test for filter-aware empty state**
+
+Add a test that produces zero results with active filters and asserts:
+
+1. an empty-state message appears
+2. it mentions no notes match the filters
+3. it echoes the active filters
+4. a clear action is visible
+
+- [ ] **Step 2: Write a failing regression test for the unfiltered empty state**
+
+Add a separate test that opens Browse with no notes at all and asserts the filtered empty-state wording does **not** appear when no filters are active.
+
+This prevents the implementation from accidentally replacing the general empty state with the filtered message.
+
+- [ ] **Step 3: Write a failing test for empty-state clear-all recovery**
+
+Add a test that invokes the empty-state clear action and asserts the full note list returns.
+
+- [ ] **Step 4: Run the focused tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests\ui\test_browse.py -k "empty_state and filter" -v
+```
+
+Expected: FAIL because the filtered empty state is not implemented yet.
+
+- [ ] **Step 5: Commit the red tests**
+
+```bash
+git add tests/ui/test_browse.py
+git commit -m "test: lock browse filtered empty state"
+```
+
+## Task 4: Implement the filtered empty state
+
+**Files:**
+- Modify: `src/cogstash/ui/browse.py`
+- Existing tests: `tests/ui/test_browse.py`
+
+- [ ] **Step 1: Add minimal empty-state UI rendering**
+
+Update `_render_cards()` so when `self._visible_cards` is empty:
+
+1. filtered-zero-result states render a dedicated empty-state block
+2. unfiltered-zero-result states do **not** render the filtered empty-state wording or clear-filters action
+
+- [ ] **Step 2: Reuse the active-filter summary wording**
+
+Avoid duplicating logic for describing filters. Extract a small helper if needed, e.g.:
+
+```python
+def _format_filter_summary(self) -> str | None:
+    ...
+```
+
+Use it for both the summary bar and the filtered empty state.
+
+- [ ] **Step 3: Reuse the same clear-all action**
+
+The empty-state button should call the same `_clear_filters()` helper used by the summary bar.
+
+- [ ] **Step 4: Run focused Browse tests**
+
+Run:
+
+```bash
+uv run pytest tests\ui\test_browse.py -k "filter_summary or clear_filters or empty_state" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the empty-state implementation**
+
+```bash
+git add src/cogstash/ui/browse.py tests/ui/test_browse.py
+git commit -m "feat: improve browse empty filter state"
+```
+
+## Task 5: Full verification and PR preparation
+
+**Files:**
+- Verify: `src/cogstash/ui/browse.py`
+- Verify: `tests/ui/test_browse.py`
+
+- [ ] **Step 1: Run focused Browse tests**
+
+Run:
+
+```bash
+uv run pytest tests\ui\test_browse.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full repo verification**
+
+Run:
+
+```bash
+uv run pytest tests\ -q
+uv run ruff check src\ tests\
+uv run mypy src\cogstash\
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Review the diff for scope control**
+
+Confirm the branch stays focused on:
+
+- `src/cogstash/ui/browse.py`
+- `tests/ui/test_browse.py`
+- issue `#18` spec/plan docs
+
+- [ ] **Step 4: Open PR and update issue `#18`**
+
+PR summary should call out:
+
+1. active filter summary bar
+2. one clear-all action
+3. filter-aware empty state

--- a/docs/superpowers/specs/2026-04-12-browse-filter-clarity.md
+++ b/docs/superpowers/specs/2026-04-12-browse-filter-clarity.md
@@ -1,0 +1,100 @@
+# Browse Filter Clarity Spec
+
+**Issue:** `#18` Improve Browse filter clarity and reset affordances
+
+**Problem**
+
+The Browse window supports combined search and tag filtering, but the active filter state is mostly implicit. Users can end up in filtered states that are not obvious, and when no notes match they are not given a clear recovery path.
+
+**Goal**
+
+Make active Browse filters obvious, give users one clear way to reset them, and make the filtered empty state explain what happened and how to recover.
+
+## In Scope
+
+1. Show active filter state more clearly when a search query or tag filter is active.
+2. Add one obvious **Clear filters** action that resets both the search query and active tag together.
+3. Improve the no-results state when filters are active so it:
+   - explains that filters produced no matches
+   - echoes the active filters
+   - offers the same **Clear filters** action
+4. Keep the interaction lightweight and consistent with the current Browse layout.
+
+## Out of Scope
+
+1. Redesigning the search field or tag pill row.
+2. Adding separate per-filter clear controls.
+3. Changing filter logic, search semantics, or tag semantics.
+4. Reworking card layout, context menu behavior, or note actions.
+
+## Agreed UX Direction
+
+The first pass should use a **compact summary bar** directly below the existing search + tag controls.
+
+### Active filter summary bar
+
+- Hidden when no filters are active.
+- Visible when:
+  - the search query is non-empty, or
+  - a tag filter is active.
+- Shows a concise readable summary of the active filters.
+- Includes a single **Clear filters** action that:
+  - clears the search query
+  - clears the active tag filter
+  - refreshes the visible note list
+
+Example summary patterns:
+
+- `Filters active: Search: "install"`
+- `Filters active: Tag: todo`
+- `Filters active: Search: "install" · Tag: todo`
+
+### Filtered empty state
+
+- When no notes match active filters, the cards area should show a dedicated filtered empty state instead of a silent blank list.
+- It must:
+  - say no notes match the current filters
+  - mention the active filters
+  - offer **Clear filters**
+- This empty state should only appear for filtered zero-result states, not for the general “there are no notes at all” case.
+
+## Behavior Details
+
+1. **No filters active**
+   - summary bar hidden
+   - normal card list behavior
+   - existing footer still updates normally
+
+2. **Search only active**
+   - summary bar visible with the search text
+   - clear action resets the search query to empty and returns to the unfiltered list
+
+3. **Tag only active**
+   - summary bar visible with the tag name
+   - clear action clears the active tag and returns to the unfiltered list
+
+4. **Search + tag active**
+   - summary bar visible with both parts in one line
+   - clear action resets both together
+
+5. **Filtered zero-result state**
+   - cards area shows filter-aware empty-state content
+   - clear action is available there too
+
+## UX Constraints
+
+- Keep the change visually small and fast to understand.
+- Do not add multiple competing reset affordances in this pass.
+- Do not introduce modal dialogs for clearing filters.
+- Keep wording concise and recovery-oriented.
+
+## Testing Expectations
+
+1. Add UI tests for summary-bar visibility/content across:
+   - no filters
+   - search only
+   - tag only
+   - combined search + tag
+2. Add UI tests for the **Clear filters** action resetting both filter inputs.
+3. Add UI tests for the filtered empty state and its clear action.
+4. Preserve existing Browse filtering behavior and current Browse tests.

--- a/src/cogstash/ui/browse.py
+++ b/src/cogstash/ui/browse.py
@@ -42,12 +42,17 @@ class BrowseWindow:
         self._context_menu: tk.Menu | None = None
         self._notice_label: tk.Label | None = None
         self._notice_after_id: str | None = None
+        self._filter_summary_frame: tk.Frame | None = None
+        self._filter_summary_label: tk.Label | None = None
+        self._clear_filters_button: tk.Button | None = None
+        self._cards_container: tk.Frame | None = None
 
         self.window = tk.Toplevel(root)
         self.window.title("CogStash — Browse Notes")
         self.window.configure(bg=self.theme["bg"])
         self.window.geometry("480x520")
         self.window.minsize(360, 300)
+        self.window.deiconify()
 
         self.search_var = tk.StringVar()
         self._build_ui()
@@ -99,12 +104,39 @@ class BrowseWindow:
             pill.bind("<Button-1>", lambda e, tg=tag: self._on_tag_filter(tg))
             self._pill_buttons[tag] = pill
 
-        # Scrollable card area
-        container = tk.Frame(self.window, bg=t["bg"])
-        container.pack(fill="both", expand=True)
+        self._filter_summary_frame = tk.Frame(self.window, bg=t["entry_bg"], padx=8, pady=6)
+        self._filter_summary_label = tk.Label(
+            self._filter_summary_frame,
+            bg=t["entry_bg"],
+            fg=t["fg"],
+            font=(fnt, 9),
+            anchor="w",
+        )
+        self._filter_summary_label.pack(side="left", fill="x", expand=True)
+        self._clear_filters_button = tk.Button(
+            self._filter_summary_frame,
+            text="Clear filters",
+            command=self._clear_filters,
+            bg=t["accent"],
+            fg=t["bg"],
+            activebackground=t["accent"],
+            activeforeground=t["bg"],
+            font=(fnt, 9, "bold"),
+            relief="flat",
+            bd=0,
+            padx=8,
+            pady=2,
+            cursor="hand2",
+            highlightthickness=0,
+        )
+        self._clear_filters_button.pack(side="right")
 
-        self.canvas = tk.Canvas(container, bg=t["bg"], highlightthickness=0, bd=0)
-        scrollbar = tk.Scrollbar(container, orient="vertical", command=self.canvas.yview)
+        # Scrollable card area
+        self._cards_container = tk.Frame(self.window, bg=t["bg"])
+        self._cards_container.pack(fill="both", expand=True)
+
+        self.canvas = tk.Canvas(self._cards_container, bg=t["bg"], highlightthickness=0, bd=0)
+        scrollbar = tk.Scrollbar(self._cards_container, orient="vertical", command=self.canvas.yview)
         self.cards_frame = tk.Frame(self.canvas, bg=t["bg"])
 
         self.cards_frame.bind(
@@ -199,6 +231,38 @@ class BrowseWindow:
             else:
                 pill.configure(bg=t["bg"], fg=t["fg"], font=(fnt, 9))
 
+    def _update_filter_summary(self):
+        """Show or hide the active-filter summary bar."""
+        if self._filter_summary_frame is None or self._filter_summary_label is None:
+            return
+
+        query = self.search_var.get().strip()
+        summary_parts: list[str] = []
+        if query:
+            summary_parts.append(f'Search: "{query}"')
+        if self._active_tag:
+            summary_parts.append(f"Tag: {self._active_tag}")
+
+        if not summary_parts:
+            self._filter_summary_frame.pack_forget()
+            self.window.update_idletasks()
+            return
+
+        self._filter_summary_label.configure(text=f'Filters active: {" · ".join(summary_parts)}')
+        if not self._filter_summary_frame.winfo_manager():
+            pack_kwargs = {"fill": "x"}
+            if self._cards_container is not None:
+                pack_kwargs["before"] = self._cards_container
+            self._filter_summary_frame.pack(**pack_kwargs)
+        self.window.update_idletasks()
+
+    def _clear_filters(self):
+        """Reset the search and tag filters, then refresh the card list."""
+        self.search_var.set("")
+        self._active_tag = None
+        self._update_pill_styles()
+        self._apply_filters()
+
     def _apply_filters(self):
         """Apply search query + tag filter, then re-render cards."""
         notes = self._all_notes
@@ -209,6 +273,7 @@ class BrowseWindow:
             notes = filter_by_tag(notes, self._active_tag)
 
         self._visible_cards = notes
+        self._update_filter_summary()
         self._render_cards()
 
     def _render_cards(self):

--- a/src/cogstash/ui/browse.py
+++ b/src/cogstash/ui/browse.py
@@ -46,6 +46,7 @@ class BrowseWindow:
         self._filter_summary_label: tk.Label | None = None
         self._clear_filters_button: tk.Button | None = None
         self._cards_container: tk.Frame | None = None
+        self._search_after_id: str | None = None
 
         self.window = tk.Toplevel(root)
         self.window.title("CogStash — Browse Notes")
@@ -208,11 +209,18 @@ class BrowseWindow:
 
     def _schedule_search(self):
         """Debounce search by 200ms."""
-        if hasattr(self, "_search_after_id"):
-            self.window.after_cancel(self._search_after_id)
+        self._cancel_pending_search()
         self._search_after_id = self.window.after(200, self._on_search)
 
+    def _cancel_pending_search(self):
+        """Cancel any queued debounced search refresh."""
+        if self._search_after_id is None:
+            return
+        self.window.after_cancel(self._search_after_id)
+        self._search_after_id = None
+
     def _on_search(self, *_args):
+        self._search_after_id = None
         self._apply_filters()
 
     def _on_tag_filter(self, tag: str | None):
@@ -244,7 +252,6 @@ class BrowseWindow:
 
         if not summary_parts:
             self._filter_summary_frame.pack_forget()
-            self.window.update_idletasks()
             return
 
         self._filter_summary_label.configure(text=f'Filters active: {" · ".join(summary_parts)}')
@@ -253,11 +260,11 @@ class BrowseWindow:
             if self._cards_container is not None:
                 pack_kwargs["before"] = self._cards_container
             self._filter_summary_frame.pack(**pack_kwargs)
-        self.window.update_idletasks()
 
     def _clear_filters(self):
         """Reset the search and tag filters, then refresh the card list."""
         self.search_var.set("")
+        self._cancel_pending_search()
         self._active_tag = None
         self._update_pill_styles()
         self._apply_filters()
@@ -274,6 +281,7 @@ class BrowseWindow:
         self._visible_cards = notes
         self._update_filter_summary()
         self._render_cards()
+        self.window.update_idletasks()
 
     def _render_cards(self):
         """Clear and re-render all visible cards."""

--- a/src/cogstash/ui/browse.py
+++ b/src/cogstash/ui/browse.py
@@ -238,23 +238,29 @@ class BrowseWindow:
             else:
                 pill.configure(bg=t["bg"], fg=t["fg"], font=(fnt, 9))
 
-    def _update_filter_summary(self):
-        """Show or hide the active-filter summary bar."""
-        if self._filter_summary_frame is None or self._filter_summary_label is None:
-            return
-
+    def _format_filter_summary(self) -> str | None:
+        """Return the active-filter summary text without the prefix."""
         query = self.search_var.get().strip()
         summary_parts: list[str] = []
         if query:
             summary_parts.append(f'Search: "{query}"')
         if self._active_tag:
             summary_parts.append(f"Tag: {self._active_tag}")
-
         if not summary_parts:
+            return None
+        return " · ".join(summary_parts)
+
+    def _update_filter_summary(self):
+        """Show or hide the active-filter summary bar."""
+        if self._filter_summary_frame is None or self._filter_summary_label is None:
+            return
+
+        summary_text = self._format_filter_summary()
+        if summary_text is None:
             self._filter_summary_frame.pack_forget()
             return
 
-        self._filter_summary_label.configure(text=f'Filters active: {" · ".join(summary_parts)}')
+        self._filter_summary_label.configure(text=f"Filters active: {summary_text}")
         if not self._filter_summary_frame.winfo_manager():
             pack_kwargs = {"fill": "x"}
             if self._cards_container is not None:
@@ -294,6 +300,47 @@ class BrowseWindow:
         today = datetime.now().date()
         yesterday = today - timedelta(days=1)
         current_date = None
+
+        if not notes:
+            summary_text = self._format_filter_summary()
+            if summary_text is not None:
+                empty_state = tk.Frame(self.cards_frame, bg=t["bg"], padx=24, pady=32)
+                empty_state.pack(fill="both", expand=True)
+
+                tk.Label(
+                    empty_state,
+                    text="No notes match the current filters.",
+                    bg=t["bg"],
+                    fg=t["fg"],
+                    font=(fnt, 11, "bold"),
+                    anchor="center",
+                    justify="center",
+                ).pack()
+                tk.Label(
+                    empty_state,
+                    text=f"Filters active: {summary_text}",
+                    bg=t["bg"],
+                    fg=t["muted"],
+                    font=(fnt, 9),
+                    anchor="center",
+                    justify="center",
+                ).pack(pady=(6, 12))
+                tk.Button(
+                    empty_state,
+                    text="Clear filters",
+                    command=self._clear_filters,
+                    bg=t["accent"],
+                    fg=t["bg"],
+                    activebackground=t["accent"],
+                    activeforeground=t["bg"],
+                    font=(fnt, 9, "bold"),
+                    relief="flat",
+                    bd=0,
+                    padx=10,
+                    pady=4,
+                    cursor="hand2",
+                    highlightthickness=0,
+                ).pack()
 
         for note in reversed(notes):  # newest first
             note_date = note.timestamp.date()

--- a/src/cogstash/ui/browse.py
+++ b/src/cogstash/ui/browse.py
@@ -129,7 +129,6 @@ class BrowseWindow:
             cursor="hand2",
             highlightthickness=0,
         )
-        self._clear_filters_button.pack(side="right")
 
         # Scrollable card area
         self._cards_container = tk.Frame(self.window, bg=t["bg"])
@@ -252,15 +251,26 @@ class BrowseWindow:
 
     def _update_filter_summary(self):
         """Show or hide the active-filter summary bar."""
-        if self._filter_summary_frame is None or self._filter_summary_label is None:
+        if (
+            self._filter_summary_frame is None
+            or self._filter_summary_label is None
+            or self._clear_filters_button is None
+        ):
             return
 
         summary_text = self._format_filter_summary()
         if summary_text is None:
+            self._clear_filters_button.pack_forget()
             self._filter_summary_frame.pack_forget()
             return
 
         self._filter_summary_label.configure(text=f"Filters active: {summary_text}")
+        if self._visible_cards:
+            if not self._clear_filters_button.winfo_manager():
+                self._clear_filters_button.pack(side="right")
+        else:
+            self._clear_filters_button.pack_forget()
+
         if not self._filter_summary_frame.winfo_manager():
             pack_kwargs = {"fill": "x"}
             if self._cards_container is not None:

--- a/src/cogstash/ui/browse.py
+++ b/src/cogstash/ui/browse.py
@@ -281,7 +281,6 @@ class BrowseWindow:
         self._visible_cards = notes
         self._update_filter_summary()
         self._render_cards()
-        self.window.update_idletasks()
 
     def _render_cards(self):
         """Clear and re-render all visible cards."""

--- a/src/cogstash/ui/browse.py
+++ b/src/cogstash/ui/browse.py
@@ -52,7 +52,6 @@ class BrowseWindow:
         self.window.configure(bg=self.theme["bg"])
         self.window.geometry("480x520")
         self.window.minsize(360, 300)
-        self.window.deiconify()
 
         self.search_var = tk.StringVar()
         self._build_ui()

--- a/tests/ui/test_browse.py
+++ b/tests/ui/test_browse.py
@@ -424,6 +424,7 @@ def test_browse_filter_empty_state_shows_message_filters_and_clear_action(tmp_pa
         empty_state_texts = _collect_widget_texts(win.cards_frame)
         empty_state_clear_button = _find_button_with_text(win.cards_frame, "Clear filters")
         expected_summary = 'Filters active: Search: "install" · Tag: idea'
+        expected_cards_filter_prefix = "Filters active:"
         expected_cards_filter_text = 'Search: "install" · Tag: idea'
 
         assert len(win._visible_cards) == 0
@@ -433,7 +434,8 @@ def test_browse_filter_empty_state_shows_message_filters_and_clear_action(tmp_pa
         assert win._filter_summary_label.cget("text") == expected_summary
         assert "No notes match the current filters." in empty_state_texts
         assert any(
-            text.startswith("Active filters:") and expected_cards_filter_text in text for text in empty_state_texts
+            text.startswith(expected_cards_filter_prefix) and expected_cards_filter_text in text
+            for text in empty_state_texts
         )
         assert empty_state_clear_button is not None
     finally:
@@ -449,13 +451,16 @@ def test_browse_filter_empty_state_stays_distinct_from_unfiltered_empty_state(tm
         win.window.update_idletasks()
 
         cards_texts = _collect_widget_texts(win.cards_frame)
+        empty_state_clear_button = _find_button_with_text(win.cards_frame, "Clear filters")
         summary_frame = getattr(win, "_filter_summary_frame", None)
+        filtered_cards_prefix = "Filters active:"
 
         assert len(win._visible_cards) == 0
         assert summary_frame is not None
         assert not summary_frame.winfo_manager()
         assert "No notes match the current filters." not in cards_texts
-        assert not any(text.startswith("Filters active:") for text in cards_texts)
+        assert not any(text.startswith(filtered_cards_prefix) for text in cards_texts)
+        assert empty_state_clear_button is None
     finally:
         win.window.destroy()
 

--- a/tests/ui/test_browse.py
+++ b/tests/ui/test_browse.py
@@ -21,6 +21,34 @@ def _make_browse_window(tmp_path, tk_root, contents: str):
     return BrowseWindow(tk_root, CogStashConfig(output_file=_make_notes_file(tmp_path, contents)))
 
 
+def _iter_descendant_widgets(widget):
+    yield widget
+    for child in widget.winfo_children():
+        yield from _iter_descendant_widgets(child)
+
+
+def _collect_widget_texts(widget):
+    texts = []
+    for child in _iter_descendant_widgets(widget):
+        try:
+            text = child.cget("text")
+        except Exception:
+            continue
+        if isinstance(text, str) and text:
+            texts.append(text)
+    return texts
+
+
+def _find_button_with_text(widget, text: str):
+    for child in _iter_descendant_widgets(widget):
+        try:
+            if child.winfo_class() == "Button" and child.cget("text") == text:
+                return child
+        except Exception:
+            continue
+    return None
+
+
 @needs_display
 def test_browse_window_creates(tmp_path, tk_root):
     """BrowseWindow opens without error."""
@@ -372,5 +400,87 @@ def test_browse_clear_filters_cancels_pending_search_before_refresh(tmp_path, tk
             win._clear_filters()
 
         assert cancelled_ids == ["search-before-clear", "search-triggered-by-clear"]
+    finally:
+        win.window.destroy()
+
+
+@needs_display
+def test_browse_filter_empty_state_shows_message_filters_and_clear_action(tmp_path, tk_root):
+    """Zero-result filtered views should render a filter-aware empty state in the cards area."""
+    win = _make_browse_window(
+        tmp_path,
+        tk_root,
+        "- [2026-03-26 14:30] install update #todo\n"
+        "- [2026-03-26 11:20] planning notes #idea\n",
+    )
+
+    try:
+        win.search_var.set("install")
+        win._on_search()
+        win._on_tag_filter("idea")
+        win.window.update_idletasks()
+
+        empty_state_texts = _collect_widget_texts(win.cards_frame)
+        empty_state_clear_button = _find_button_with_text(win.cards_frame, "Clear filters")
+        expected_summary = 'Filters active: Search: "install" · Tag: idea'
+
+        assert len(win._visible_cards) == 0
+        assert win._filter_summary_label is not None
+        assert win._filter_summary_label.cget("text") == expected_summary
+        assert "No notes match the current filters." in empty_state_texts
+        assert expected_summary in empty_state_texts
+        assert empty_state_clear_button is not None
+    finally:
+        win.window.destroy()
+
+
+@needs_display
+def test_browse_filter_empty_state_stays_distinct_from_unfiltered_empty_state(tmp_path, tk_root):
+    """The filtered empty-state wording should not appear when Browse has no notes and no filters."""
+    win = _make_browse_window(tmp_path, tk_root, "")
+
+    try:
+        win.window.update_idletasks()
+
+        cards_texts = _collect_widget_texts(win.cards_frame)
+        summary_frame = getattr(win, "_filter_summary_frame", None)
+
+        assert len(win._visible_cards) == 0
+        assert summary_frame is not None
+        assert not summary_frame.winfo_manager()
+        assert "No notes match the current filters." not in cards_texts
+        assert not any(text.startswith("Filters active:") for text in cards_texts)
+    finally:
+        win.window.destroy()
+
+
+@needs_display
+def test_browse_filter_empty_state_clear_action_restores_full_list(tmp_path, tk_root):
+    """Clearing filters from the empty state should restore the unfiltered list."""
+    win = _make_browse_window(
+        tmp_path,
+        tk_root,
+        "- [2026-03-26 14:30] install update #todo\n"
+        "- [2026-03-26 11:20] planning notes #idea\n",
+    )
+
+    try:
+        win.search_var.set("install")
+        win._on_search()
+        win._on_tag_filter("idea")
+        win.window.update_idletasks()
+
+        empty_state_clear_button = _find_button_with_text(win.cards_frame, "Clear filters")
+
+        assert len(win._visible_cards) == 0
+        assert empty_state_clear_button is not None
+
+        empty_state_clear_button.invoke()
+        win.window.update_idletasks()
+
+        assert win.search_var.get() == ""
+        assert win._active_tag is None
+        assert len(win._visible_cards) == 2
+        assert "No notes match the current filters." not in _collect_widget_texts(win.cards_frame)
     finally:
         win.window.destroy()

--- a/tests/ui/test_browse.py
+++ b/tests/ui/test_browse.py
@@ -282,9 +282,12 @@ def test_browse_clear_filters_resets_search_tag_and_full_list(tmp_path, tk_root)
         win._on_tag_filter("todo")
         win.window.update_idletasks()
 
+        summary_frame = getattr(win, "_filter_summary_frame", None)
         clear_filters_button = getattr(win, "_clear_filters_button", None)
 
         assert len(win._visible_cards) == 1
+        assert summary_frame is not None
+        assert summary_frame.winfo_ismapped()
         assert clear_filters_button is not None
 
         clear_filters_button.invoke()

--- a/tests/ui/test_browse.py
+++ b/tests/ui/test_browse.py
@@ -420,15 +420,17 @@ def test_browse_filter_empty_state_shows_message_filters_and_clear_action(tmp_pa
         win._on_tag_filter("idea")
         win.window.update_idletasks()
 
+        summary_frame = getattr(win, "_filter_summary_frame", None)
         empty_state_texts = _collect_widget_texts(win.cards_frame)
         empty_state_clear_button = _find_button_with_text(win.cards_frame, "Clear filters")
         expected_summary = 'Filters active: Search: "install" · Tag: idea'
 
         assert len(win._visible_cards) == 0
+        assert summary_frame is not None
+        assert summary_frame.winfo_manager() == "pack"
         assert win._filter_summary_label is not None
         assert win._filter_summary_label.cget("text") == expected_summary
         assert "No notes match the current filters." in empty_state_texts
-        assert expected_summary in empty_state_texts
         assert empty_state_clear_button is not None
     finally:
         win.window.destroy()

--- a/tests/ui/test_browse.py
+++ b/tests/ui/test_browse.py
@@ -194,7 +194,39 @@ def test_browse_filter_summary_hidden_when_no_filters_active(tmp_path, tk_root):
 
         assert len(win._visible_cards) == 2
         summary_frame = getattr(win, "_filter_summary_frame", None)
-        assert summary_frame is None or not summary_frame.winfo_ismapped()
+        assert summary_frame is not None
+        assert not summary_frame.winfo_ismapped()
+    finally:
+        win.window.destroy()
+
+
+@needs_display
+def test_browse_apply_filters_renders_cards_before_idletasks_flush(tmp_path, tk_root):
+    """Applying filters should not flush idle tasks before cards are rerendered."""
+    win = _make_browse_window(
+        tmp_path,
+        tk_root,
+        "- [2026-03-26 14:30] install update #todo\n"
+        "- [2026-03-26 11:20] planning notes #idea\n",
+    )
+
+    events: list[str] = []
+    original_render_cards = win._render_cards
+
+    def _record_render():
+        events.append("render")
+        original_render_cards()
+
+    try:
+        with (
+            patch("cogstash.ui.browse.tk.Misc.update_idletasks", side_effect=lambda *_args: events.append("update")),
+            patch.object(win, "_render_cards", side_effect=_record_render),
+        ):
+            win._on_tag_filter("todo")
+
+        assert "render" in events
+        if "update" in events:
+            assert events.index("render") < events.index("update")
     finally:
         win.window.destroy()
 
@@ -315,5 +347,32 @@ def test_browse_clear_filters_resets_search_tag_and_full_list(tmp_path, tk_root)
         assert win._active_tag is None
         assert len(win._visible_cards) == 3
         assert summary_frame is None or not summary_frame.winfo_ismapped()
+    finally:
+        win.window.destroy()
+
+
+@needs_display
+def test_browse_clear_filters_cancels_pending_search_before_refresh(tmp_path, tk_root):
+    """Clearing filters should cancel any scheduled search before direct refresh."""
+    win = _make_browse_window(
+        tmp_path,
+        tk_root,
+        "- [2026-03-26 14:30] install update #todo\n"
+        "- [2026-03-26 12:15] install backup #idea\n"
+        "- [2026-03-26 11:20] planning notes #todo\n",
+    )
+
+    cancelled_ids: list[str] = []
+
+    try:
+        win._search_after_id = "search-before-clear"
+
+        with (
+            patch.object(win.window, "after", return_value="search-triggered-by-clear"),
+            patch.object(win.window, "after_cancel", side_effect=cancelled_ids.append),
+        ):
+            win._clear_filters()
+
+        assert cancelled_ids == ["search-before-clear", "search-triggered-by-clear"]
     finally:
         win.window.destroy()

--- a/tests/ui/test_browse.py
+++ b/tests/ui/test_browse.py
@@ -49,6 +49,17 @@ def _find_button_with_text(widget, text: str):
     return None
 
 
+def _find_visible_buttons_with_text(widget, text: str):
+    buttons = []
+    for child in _iter_descendant_widgets(widget):
+        try:
+            if child.winfo_class() == "Button" and child.cget("text") == text and child.winfo_ismapped():
+                buttons.append(child)
+        except Exception:
+            continue
+    return buttons
+
+
 @needs_display
 def test_browse_window_creates(tmp_path, tk_root):
     """BrowseWindow opens without error."""
@@ -438,6 +449,33 @@ def test_browse_filter_empty_state_shows_message_filters_and_clear_action(tmp_pa
             for text in empty_state_texts
         )
         assert empty_state_clear_button is not None
+    finally:
+        win.window.destroy()
+
+
+@needs_display
+def test_browse_filter_empty_state_keeps_summary_bar_but_one_clear_action(tmp_path, tk_root):
+    """Zero-result filtered views should keep the summary bar but show one visible clear-filters action."""
+    win = _make_browse_window(
+        tmp_path,
+        tk_root,
+        "- [2026-03-26 14:30] install update #todo\n"
+        "- [2026-03-26 11:20] planning notes #idea\n",
+    )
+
+    try:
+        win.search_var.set("install")
+        win._on_search()
+        win._on_tag_filter("idea")
+        win.window.update()
+
+        summary_frame = getattr(win, "_filter_summary_frame", None)
+        visible_clear_buttons = _find_visible_buttons_with_text(win.window, "Clear filters")
+
+        assert len(win._visible_cards) == 0
+        assert summary_frame is not None
+        assert summary_frame.winfo_manager() == "pack"
+        assert visible_clear_buttons == [_find_button_with_text(win.cards_frame, "Clear filters")]
     finally:
         win.window.destroy()
 

--- a/tests/ui/test_browse.py
+++ b/tests/ui/test_browse.py
@@ -195,14 +195,14 @@ def test_browse_filter_summary_hidden_when_no_filters_active(tmp_path, tk_root):
         assert len(win._visible_cards) == 2
         summary_frame = getattr(win, "_filter_summary_frame", None)
         assert summary_frame is not None
-        assert not summary_frame.winfo_ismapped()
+        assert not summary_frame.winfo_manager()
     finally:
         win.window.destroy()
 
 
 @needs_display
 def test_browse_apply_filters_renders_cards_before_idletasks_flush(tmp_path, tk_root):
-    """Applying filters should not flush idle tasks before cards are rerendered."""
+    """Applying filters should rerender cards without forcing an idle-task flush."""
     win = _make_browse_window(
         tmp_path,
         tk_root,
@@ -224,9 +224,7 @@ def test_browse_apply_filters_renders_cards_before_idletasks_flush(tmp_path, tk_
         ):
             win._on_tag_filter("todo")
 
-        assert "render" in events
-        if "update" in events:
-            assert events.index("render") < events.index("update")
+        assert events == ["render"]
     finally:
         win.window.destroy()
 
@@ -253,7 +251,7 @@ def test_browse_filter_summary_shows_combined_search_and_tag(tmp_path, tk_root):
 
         assert len(win._visible_cards) == 1
         assert summary_frame is not None
-        assert summary_frame.winfo_ismapped()
+        assert summary_frame.winfo_manager() == "pack"
         assert summary_label is not None
         assert summary_label.cget("text") == 'Filters active: Search: "install" · Tag: todo'
     finally:
@@ -280,7 +278,7 @@ def test_browse_filter_summary_shows_search_only_state(tmp_path, tk_root):
 
         assert len(win._visible_cards) == 1
         assert summary_frame is not None
-        assert summary_frame.winfo_ismapped()
+        assert summary_frame.winfo_manager() == "pack"
         assert summary_label is not None
         assert summary_label.cget("text") == 'Filters active: Search: "install"'
     finally:
@@ -306,7 +304,7 @@ def test_browse_filter_summary_shows_tag_only_state(tmp_path, tk_root):
 
         assert len(win._visible_cards) == 1
         assert summary_frame is not None
-        assert summary_frame.winfo_ismapped()
+        assert summary_frame.winfo_manager() == "pack"
         assert summary_label is not None
         assert summary_label.cget("text") == "Filters active: Tag: todo"
     finally:
@@ -335,7 +333,7 @@ def test_browse_clear_filters_resets_search_tag_and_full_list(tmp_path, tk_root)
 
         assert len(win._visible_cards) == 1
         assert summary_frame is not None
-        assert summary_frame.winfo_ismapped()
+        assert summary_frame.winfo_manager() == "pack"
         assert clear_filters_button is not None
 
         clear_filters_button.invoke()
@@ -346,7 +344,7 @@ def test_browse_clear_filters_resets_search_tag_and_full_list(tmp_path, tk_root)
         assert win.search_var.get() == ""
         assert win._active_tag is None
         assert len(win._visible_cards) == 3
-        assert summary_frame is None or not summary_frame.winfo_ismapped()
+        assert summary_frame is None or not summary_frame.winfo_manager()
     finally:
         win.window.destroy()
 

--- a/tests/ui/test_browse.py
+++ b/tests/ui/test_browse.py
@@ -8,6 +8,19 @@ from unittest.mock import patch
 from ui._support import needs_display
 
 
+def _make_notes_file(tmp_path, contents: str):
+    f = tmp_path / "cogstash.md"
+    f.write_text(contents, encoding="utf-8")
+    return f
+
+
+def _make_browse_window(tmp_path, tk_root, contents: str):
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
+
+    return BrowseWindow(tk_root, CogStashConfig(output_file=_make_notes_file(tmp_path, contents)))
+
+
 @needs_display
 def test_browse_window_creates(tmp_path, tk_root):
     """BrowseWindow opens without error."""
@@ -148,3 +161,119 @@ def test_browse_stale_edit_reloads_and_shows_notice(tmp_path, tk_root):
     notice_mock.assert_called_once()
     error_mock.assert_not_called()
     win.window.destroy()
+
+
+@needs_display
+def test_browse_filter_summary_hidden_when_no_filters_active(tmp_path, tk_root):
+    """No active filters should keep the summary bar hidden."""
+    win = _make_browse_window(
+        tmp_path,
+        tk_root,
+        "- [2026-03-26 14:30] install update #todo\n"
+        "- [2026-03-26 11:20] planning notes #idea\n",
+    )
+
+    try:
+        win.window.update_idletasks()
+
+        assert len(win._visible_cards) == 2
+        assert win._filter_summary_bar.winfo_manager() == ""
+    finally:
+        win.window.destroy()
+
+
+@needs_display
+def test_browse_filter_summary_shows_combined_search_and_tag(tmp_path, tk_root):
+    """Combined search and tag filters should show one joined summary string."""
+    win = _make_browse_window(
+        tmp_path,
+        tk_root,
+        "- [2026-03-26 14:30] install update #todo\n"
+        "- [2026-03-26 12:15] install backup #idea\n"
+        "- [2026-03-26 11:20] planning notes #todo\n",
+    )
+
+    try:
+        win.search_var.set("install")
+        win._on_search()
+        win._on_tag_filter("todo")
+        win.window.update_idletasks()
+
+        assert len(win._visible_cards) == 1
+        assert win._filter_summary_bar.winfo_manager() == "pack"
+        assert win._filter_summary_label.cget("text") == 'Filters active: Search: "install" · Tag: todo'
+    finally:
+        win.window.destroy()
+
+
+@needs_display
+def test_browse_filter_summary_shows_search_only_state(tmp_path, tk_root):
+    """Search-only filtering should show the search summary text."""
+    win = _make_browse_window(
+        tmp_path,
+        tk_root,
+        "- [2026-03-26 14:30] install update #todo\n"
+        "- [2026-03-26 11:20] planning notes #idea\n",
+    )
+
+    try:
+        win.search_var.set("install")
+        win._on_search()
+        win.window.update_idletasks()
+
+        assert len(win._visible_cards) == 1
+        assert win._filter_summary_bar.winfo_manager() == "pack"
+        assert win._filter_summary_label.cget("text") == 'Filters active: Search: "install"'
+    finally:
+        win.window.destroy()
+
+
+@needs_display
+def test_browse_filter_summary_shows_tag_only_state(tmp_path, tk_root):
+    """Tag-only filtering should show the tag summary text."""
+    win = _make_browse_window(
+        tmp_path,
+        tk_root,
+        "- [2026-03-26 14:30] install update #todo\n"
+        "- [2026-03-26 11:20] planning notes #idea\n",
+    )
+
+    try:
+        win._on_tag_filter("todo")
+        win.window.update_idletasks()
+
+        assert len(win._visible_cards) == 1
+        assert win._filter_summary_bar.winfo_manager() == "pack"
+        assert win._filter_summary_label.cget("text") == "Filters active: Tag: todo"
+    finally:
+        win.window.destroy()
+
+
+@needs_display
+def test_browse_clear_filters_resets_search_tag_and_full_list(tmp_path, tk_root):
+    """Clear filters should reset search, tag, and restore the full card list."""
+    win = _make_browse_window(
+        tmp_path,
+        tk_root,
+        "- [2026-03-26 14:30] install update #todo\n"
+        "- [2026-03-26 12:15] install backup #idea\n"
+        "- [2026-03-26 11:20] planning notes #todo\n",
+    )
+
+    try:
+        win.search_var.set("install")
+        win._on_search()
+        win._on_tag_filter("todo")
+        win.window.update_idletasks()
+
+        assert len(win._visible_cards) == 1
+
+        win._clear_filters_button.invoke()
+        win.window.update_idletasks()
+
+        assert win.search_var.get() == ""
+        assert win._active_tag is None
+        assert len(win._visible_cards) == 3
+        assert win._filter_summary_bar.winfo_manager() == ""
+    finally:
+        win.window.destroy()

--- a/tests/ui/test_browse.py
+++ b/tests/ui/test_browse.py
@@ -37,6 +37,22 @@ def test_browse_window_creates(tmp_path, tk_root):
 
 
 @needs_display
+def test_browse_window_does_not_force_deiconify_on_create(tmp_path, tk_root):
+    """BrowseWindow should not force the toplevel to deiconify during creation."""
+    f = tmp_path / "cogstash.md"
+    f.write_text("- [2026-03-26 14:30] ☐ test note #todo\n", encoding="utf-8")
+
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
+
+    with patch("cogstash.ui.browse.tk.Toplevel.deiconify") as deiconify_mock:
+        win = BrowseWindow(tk_root, CogStashConfig(output_file=f))
+
+    assert deiconify_mock.call_count == 0
+    win.window.destroy()
+
+
+@needs_display
 def test_browse_search_filters(tmp_path, tk_root):
     """Typing in search box reduces visible cards."""
     f = tmp_path / "cogstash.md"

--- a/tests/ui/test_browse.py
+++ b/tests/ui/test_browse.py
@@ -424,6 +424,7 @@ def test_browse_filter_empty_state_shows_message_filters_and_clear_action(tmp_pa
         empty_state_texts = _collect_widget_texts(win.cards_frame)
         empty_state_clear_button = _find_button_with_text(win.cards_frame, "Clear filters")
         expected_summary = 'Filters active: Search: "install" · Tag: idea'
+        expected_cards_filter_text = 'Search: "install" · Tag: idea'
 
         assert len(win._visible_cards) == 0
         assert summary_frame is not None
@@ -431,6 +432,9 @@ def test_browse_filter_empty_state_shows_message_filters_and_clear_action(tmp_pa
         assert win._filter_summary_label is not None
         assert win._filter_summary_label.cget("text") == expected_summary
         assert "No notes match the current filters." in empty_state_texts
+        assert any(
+            text.startswith("Active filters:") and expected_cards_filter_text in text for text in empty_state_texts
+        )
         assert empty_state_clear_button is not None
     finally:
         win.window.destroy()

--- a/tests/ui/test_browse.py
+++ b/tests/ui/test_browse.py
@@ -177,7 +177,8 @@ def test_browse_filter_summary_hidden_when_no_filters_active(tmp_path, tk_root):
         win.window.update_idletasks()
 
         assert len(win._visible_cards) == 2
-        assert win._filter_summary_bar.winfo_manager() == ""
+        summary_frame = getattr(win, "_filter_summary_frame", None)
+        assert summary_frame is None or not summary_frame.winfo_ismapped()
     finally:
         win.window.destroy()
 
@@ -199,9 +200,14 @@ def test_browse_filter_summary_shows_combined_search_and_tag(tmp_path, tk_root):
         win._on_tag_filter("todo")
         win.window.update_idletasks()
 
+        summary_frame = getattr(win, "_filter_summary_frame", None)
+        summary_label = getattr(win, "_filter_summary_label", None)
+
         assert len(win._visible_cards) == 1
-        assert win._filter_summary_bar.winfo_manager() == "pack"
-        assert win._filter_summary_label.cget("text") == 'Filters active: Search: "install" · Tag: todo'
+        assert summary_frame is not None
+        assert summary_frame.winfo_ismapped()
+        assert summary_label is not None
+        assert summary_label.cget("text") == 'Filters active: Search: "install" · Tag: todo'
     finally:
         win.window.destroy()
 
@@ -221,9 +227,14 @@ def test_browse_filter_summary_shows_search_only_state(tmp_path, tk_root):
         win._on_search()
         win.window.update_idletasks()
 
+        summary_frame = getattr(win, "_filter_summary_frame", None)
+        summary_label = getattr(win, "_filter_summary_label", None)
+
         assert len(win._visible_cards) == 1
-        assert win._filter_summary_bar.winfo_manager() == "pack"
-        assert win._filter_summary_label.cget("text") == 'Filters active: Search: "install"'
+        assert summary_frame is not None
+        assert summary_frame.winfo_ismapped()
+        assert summary_label is not None
+        assert summary_label.cget("text") == 'Filters active: Search: "install"'
     finally:
         win.window.destroy()
 
@@ -242,9 +253,14 @@ def test_browse_filter_summary_shows_tag_only_state(tmp_path, tk_root):
         win._on_tag_filter("todo")
         win.window.update_idletasks()
 
+        summary_frame = getattr(win, "_filter_summary_frame", None)
+        summary_label = getattr(win, "_filter_summary_label", None)
+
         assert len(win._visible_cards) == 1
-        assert win._filter_summary_bar.winfo_manager() == "pack"
-        assert win._filter_summary_label.cget("text") == "Filters active: Tag: todo"
+        assert summary_frame is not None
+        assert summary_frame.winfo_ismapped()
+        assert summary_label is not None
+        assert summary_label.cget("text") == "Filters active: Tag: todo"
     finally:
         win.window.destroy()
 
@@ -266,14 +282,19 @@ def test_browse_clear_filters_resets_search_tag_and_full_list(tmp_path, tk_root)
         win._on_tag_filter("todo")
         win.window.update_idletasks()
 
-        assert len(win._visible_cards) == 1
+        clear_filters_button = getattr(win, "_clear_filters_button", None)
 
-        win._clear_filters_button.invoke()
+        assert len(win._visible_cards) == 1
+        assert clear_filters_button is not None
+
+        clear_filters_button.invoke()
         win.window.update_idletasks()
+
+        summary_frame = getattr(win, "_filter_summary_frame", None)
 
         assert win.search_var.get() == ""
         assert win._active_tag is None
         assert len(win._visible_cards) == 3
-        assert win._filter_summary_bar.winfo_manager() == ""
+        assert summary_frame is None or not summary_frame.winfo_ismapped()
     finally:
         win.window.destroy()

--- a/tests/ui/test_browse.py
+++ b/tests/ui/test_browse.py
@@ -427,7 +427,7 @@ def test_browse_filter_empty_state_shows_message_filters_and_clear_action(tmp_pa
 
         assert len(win._visible_cards) == 0
         assert summary_frame is not None
-        assert summary_frame.winfo_manager() == "pack"
+        assert summary_frame.winfo_manager()
         assert win._filter_summary_label is not None
         assert win._filter_summary_label.cget("text") == expected_summary
         assert "No notes match the current filters." in empty_state_texts


### PR DESCRIPTION
## Summary
- add a compact browse filter summary bar with clear filter handling for search-only, tag-only, and combined states
- add a filter-aware zero-results empty state that echoes active filters and offers one clear recovery action
- add issue #18 spec/plan docs and Browse UI tests covering summary, empty-state, and clear-action behavior

## Test Plan
- [x] uv run pytest tests\ -q
- [x] uv run ruff check src\ tests\
- [x] uv run mypy src\cogstash\