### PR TITLE
Finish issue 11 UX follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ a card-based UI, or query from the command line.
 - 🏷️ **Smart tags** — `#todo`, `#urgent`, `#important`, `#idea` with emoji prefixes
 - 🔤 **Autocomplete** — type `#` and pick a tag from the popup
 - ✨ **Guided onboarding** — first-run wizard for new users plus lightweight installed-build welcome/upgrade flow
-- ⚙️ **Settings window** — theme, window size, startup, and custom tag management from the UI, with hotkey shown for reference
+- ⚙️ **Settings window** — theme, window size, startup, hotkey, and custom tag management from the UI
 - 🎨 **Themes** — 5 built-in color schemes (tokyo-night, light, dracula, gruvbox, mono)
-- 🗂️ **Browse window** — card view with live search, tag filtering, and mark-done
+- 🗂️ **Browse window** — card view with live search, tag filtering, safer delete preview, undo, and mark-done
 - 💻 **CLI commands** — `recent`, `search`, `tags`, `add`, `edit`, `delete`, `export`, `stats`, and `config`
 - 🖥️ **System tray** — runs quietly in the background with a tray icon menu
 - 🌍 **Cross-platform** — Windows, macOS, and Linux
@@ -57,6 +57,17 @@ On Windows you can now choose between:
 - `CogStash-vX.Y.Z-setup.exe` — installs `CogStash.exe` and `CogStash-CLI.exe` to `%LocalAppData%\Programs\CogStash`, adds an Apps & Features entry, creates Start Menu/Desktop shortcuts only for the UI app, and can optionally enable launch at sign-in plus add the installed CLI directory to `PATH` during setup.
 - `CogStash-vX.Y.Z-windows.exe` — portable onefile executable; download and run without installing.
 - `CogStash-CLI-vX.Y.Z-windows.exe` — portable CLI executable for shell-only usage.
+
+### Which Download Should I Choose?
+
+| If you want... | Choose... |
+|----------------|-----------|
+| the easiest Windows setup with shortcuts, uninstall support, and optional `PATH` / startup integration | `CogStash-vX.Y.Z-setup.exe` |
+| the normal UI app without installing anything | `CogStash-vX.Y.Z-windows.exe` |
+| the CLI only for shell workflows | `CogStash-CLI-vX.Y.Z-windows.exe` |
+| the UI app as an extracted folder instead of a single file | `.zip` / `.tar.gz` onedir bundle |
+| macOS or Linux UI app | `CogStash-vX.Y.Z-macos` or `CogStash-vX.Y.Z-linux` |
+| macOS or Linux CLI only | `CogStash-CLI-vX.Y.Z-macos` or `CogStash-CLI-vX.Y.Z-linux` |
 
 > **Tip:** The `.zip` / `.tar.gz` files are UI onedir bundles (a folder with all files).
 > They start slightly faster but aren't a single portable file.
@@ -103,6 +114,21 @@ uv run cogstash
 python -m cogstash --help
 ```
 
+### Quick Verification After Download or Install
+
+Use the shortest check that matches what you downloaded:
+
+| Artifact | Verify with |
+|----------|-------------|
+| Windows installer | Launch **CogStash** from Start Menu, confirm the tray icon appears, then run `CogStash-CLI.exe --help` if you enabled the installer `PATH` option |
+| Windows portable UI | Run `./CogStash-vX.Y.Z-windows.exe`, confirm the tray icon appears, then press the hotkey once |
+| Windows portable CLI | Run `./CogStash-CLI-vX.Y.Z-windows.exe --help` and `./CogStash-CLI-vX.Y.Z-windows.exe --version` |
+| macOS / Linux UI binary | Run the UI binary, confirm it stays running and shows the tray / menu-bar presence supported by your desktop |
+| macOS / Linux CLI binary | Run `./CogStash-CLI-vX.Y.Z-<platform> --help` and `--version` |
+| source install | Run `uv run cogstash` for the UI or `python -m cogstash --help` for CLI dispatch |
+
+If the UI starts cleanly, the tray/menu icon stays present, and the default hotkey opens the capture window, the installation is working.
+
 CogStash starts in the system tray. Press the hotkey to capture a note:
 
 | Key | Action |
@@ -127,7 +153,7 @@ Multi-line notes use 2-space indented continuation lines.
 New users see the first-run wizard on their first launch. After that, use the tray icon to open:
 
 - **Browse Notes** for searching, filtering, editing, and marking notes done
-- **Settings** for theme, window size, startup, and tag preferences, with the current hotkey shown for reference
+- **Settings** for theme, window size, startup, hotkey, and tag preferences
 
 ---
 
@@ -173,6 +199,7 @@ Show the most recent notes (newest first).
 ```bash
 cogstash recent            # last 20 notes (default)
 cogstash recent --limit 5  # last 5 notes
+cogstash recent --tag todo # last todo notes only
 ```
 
 ### `cogstash search`
@@ -182,6 +209,7 @@ Full-text search across all notes. Case-insensitive, multi-word AND matching.
 ```bash
 cogstash search "buy milk"        # notes containing "buy" AND "milk"
 cogstash search "todo" --limit 10 # limit results
+cogstash search "deploy" --tag urgent
 ```
 
 ### `cogstash tags`
@@ -243,6 +271,7 @@ Export all notes to JSON, CSV, or Markdown. Without `--output`, CogStash writes 
 cogstash export --format json
 cogstash export --format csv --output notes.csv
 cogstash export --format md --output notes.md
+cogstash export --format json --tag todo --output todo-notes.json
 ```
 
 ### `cogstash stats`

--- a/src/cogstash/cli/main.py
+++ b/src/cogstash/cli/main.py
@@ -13,6 +13,7 @@ from cogstash.core import (
     compute_stats,
     delete_note,
     edit_note,
+    filter_by_tag,
     get_default_config_path,
     load_config,
     merge_tags,
@@ -51,11 +52,22 @@ def _output_file(config: CogStashConfig) -> Path:
     return output_file
 
 
+def _apply_tag_filter(notes: list[Note], tag: str | None) -> list[Note]:
+    """Optionally restrict a note list to one tag."""
+    if not tag:
+        return notes
+    return filter_by_tag(notes, tag)
+
+
 def cmd_recent(args, config: CogStashConfig, ansi_tag=None):
     """Show the most recent N notes."""
-    notes = parse_notes(_output_file(config))
+    tag = getattr(args, "tag", None)
+    notes = _apply_tag_filter(parse_notes(_output_file(config)), tag)
     if not notes:
-        safe_print("No notes found.")
+        if tag:
+            safe_print(f"No notes found for tag #{tag}.")
+        else:
+            safe_print("No notes found.")
         return
 
     use_color = stream_supports_color(sys.stdout)
@@ -68,11 +80,15 @@ def cmd_recent(args, config: CogStashConfig, ansi_tag=None):
 
 def cmd_search(args, config: CogStashConfig, ansi_tag=None):
     """Search notes by keyword."""
-    notes = parse_notes(_output_file(config))
+    tag = getattr(args, "tag", None)
+    notes = _apply_tag_filter(parse_notes(_output_file(config)), tag)
     results = search_notes(notes, args.query)
 
     if not results:
-        safe_print("No matching notes.")
+        if tag:
+            safe_print(f"No matching notes for tag #{tag}.")
+        else:
+            safe_print("No matching notes.")
         return
 
     use_color = stream_supports_color(sys.stdout)
@@ -212,9 +228,13 @@ def cmd_export(args, config: CogStashConfig, ansi_tag=None):
     import csv
     import json as json_mod
 
-    notes = parse_notes(_output_file(config))
+    tag = getattr(args, "tag", None)
+    notes = _apply_tag_filter(parse_notes(_output_file(config)), tag)
     if not notes:
-        safe_print("No notes to export.")
+        if tag:
+            safe_print(f"No notes found for tag #{tag}.")
+        else:
+            safe_print("No notes to export.")
         return
 
     today = datetime.now().strftime("%Y-%m-%d")
@@ -480,11 +500,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_recent = sub.add_parser("recent", help="Show latest notes")
     p_recent.add_argument("--limit", type=int, default=20, help="Max notes to show (default: 20)")
+    p_recent.add_argument("--tag", help="Only include notes with this tag")
     p_recent.set_defaults(func=cmd_recent)
 
     p_search = sub.add_parser("search", help="Search notes by keyword")
     p_search.add_argument("query", help="Search term")
     p_search.add_argument("--limit", type=int, default=20, help="Max results (default: 20)")
+    p_search.add_argument("--tag", help="Only search within notes with this tag")
     p_search.set_defaults(func=cmd_search)
 
     p_tags = sub.add_parser("tags", help="List all tags with counts")
@@ -536,6 +558,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_export = sub.add_parser("export", help="Export all notes to file")
     p_export.add_argument("--format", "-f", choices=["json", "csv", "md"], default="json", help="Export format (default: json)")
     p_export.add_argument("--output", "-o", help="Output file path (default: auto-named)")
+    p_export.add_argument("--tag", help="Only export notes with this tag")
     p_export.set_defaults(func=cmd_export)
 
     p_stats = sub.add_parser("stats", help="Show note statistics")

--- a/src/cogstash/ui/browse.py
+++ b/src/cogstash/ui/browse.py
@@ -12,6 +12,7 @@ import tkinter as tk
 from datetime import datetime, timedelta
 
 from cogstash.search import (
+    _atomic_write,
     DEFAULT_TAG_COLORS,
     Note,
     delete_note,
@@ -41,7 +42,9 @@ class BrowseWindow:
         self._card_frames: list[tk.Frame] = []
         self._context_menu: tk.Menu | None = None
         self._notice_label: tk.Label | None = None
+        self._notice_button: tk.Button | None = None
         self._notice_after_id: str | None = None
+        self._last_deleted_note: tuple[Note, list[str]] | None = None
         self._filter_summary_frame: tk.Frame | None = None
         self._filter_summary_label: tk.Label | None = None
         self._clear_filters_button: tk.Button | None = None
@@ -570,18 +573,61 @@ class BrowseWindow:
     def _on_delete(self, note: Note):
         """Delete a note with confirmation dialog."""
         from tkinter import messagebox
-        preview = note.text[:50] + ("..." if len(note.text) > 50 else "")
+        preview = self._build_delete_preview(note)
         if messagebox.askyesno(
             "Delete Note",
-            f"Delete this note?\n\n\"{preview}\"",
+            f"Delete this note?\n\nPreview:\n{preview}",
             parent=self.window,
         ):
             assert self.config.output_file is not None, "output_file should be set by __post_init__"
             if delete_note(self.config.output_file, note):
+                self._last_deleted_note = (note, self._serialize_note_lines(note))
                 self._all_notes = [existing for existing in self._all_notes if existing is not note]
                 self._apply_filters()
+                self._show_notice("Note deleted", action_label="Undo", action=self._undo_delete)
                 return
             self._handle_stale_action()
+
+    def _build_delete_preview(self, note: Note) -> str:
+        """Return a readable delete preview for confirmation dialogs."""
+        preview_lines = note.text.splitlines()[:3]
+        preview = "\n".join(preview_lines)
+        if len(note.text.splitlines()) > 3 or len(preview) > 180:
+            preview = preview[:177].rstrip()
+            preview += "..."
+        return preview
+
+    def _serialize_note_lines(self, note: Note) -> list[str]:
+        """Render a note back into on-disk line form for session-level undo."""
+        timestamp = note.timestamp.strftime("%Y-%m-%d %H:%M")
+        text_lines = note.text.split("\n")
+        rendered = [f"- [{timestamp}] {text_lines[0]}\n"]
+        rendered.extend(f"  {line}\n" for line in text_lines[1:])
+        return rendered
+
+    def _undo_delete(self) -> None:
+        """Restore the most recently deleted note for this session."""
+        if self._last_deleted_note is None:
+            return
+        note, rendered_lines = self._last_deleted_note
+        assert self.config.output_file is not None, "output_file should be set by __post_init__"
+        try:
+            lines = self.config.output_file.read_text(encoding="utf-8").splitlines(keepends=True)
+        except OSError:
+            self._show_notice("Could not restore deleted note")
+            return
+
+        insert_at = min(note.line_number, len(lines))
+        lines[insert_at:insert_at] = rendered_lines
+        try:
+            _atomic_write(self.config.output_file, "".join(lines))
+        except OSError:
+            self._show_notice("Could not restore deleted note")
+            return
+
+        self._last_deleted_note = None
+        self._load_notes()
+        self._show_notice("Deletion undone")
 
     def _on_copy(self, note: Note):
         """Copy note text to clipboard."""
@@ -594,30 +640,52 @@ class BrowseWindow:
         self._load_notes()
         self._show_notice("Notes changed on disk — reloaded")
 
-    def _show_notice(self, text: str) -> None:
+    def _show_notice(self, text: str, action_label: str | None = None, action=None) -> None:
         """Show a brief non-blocking status notice."""
         if self._notice_after_id is not None:
             self.window.after_cancel(self._notice_after_id)
             self._notice_after_id = None
-        if self._notice_label is not None and self._notice_label.winfo_exists():
-            self._notice_label.destroy()
+        self._clear_notice()
+
+        notice_frame = tk.Frame(self.window, bg=self.theme["accent"], padx=10, pady=4)
         self._notice_label = tk.Label(
-            self.window,
+            notice_frame,
             text=text,
             bg=self.theme["accent"],
             fg=self.theme["bg"],
             font=(platform_font(), 9),
-            padx=10,
-            pady=4,
         )
-        self._notice_label.place(relx=0.5, rely=0.94, anchor="center")
-        self._notice_after_id = self.window.after(1500, self._clear_notice)
+        self._notice_label.pack(side="left")
+        if action_label and action is not None:
+            self._notice_button = tk.Button(
+                notice_frame,
+                text=action_label,
+                command=action,
+                bg=self.theme["bg"],
+                fg=self.theme["accent"],
+                activebackground=self.theme["bg"],
+                activeforeground=self.theme["accent"],
+                font=(platform_font(), 9, "bold"),
+                relief="flat",
+                bd=0,
+                padx=8,
+                pady=1,
+                cursor="hand2",
+                highlightthickness=0,
+            )
+            self._notice_button.pack(side="left", padx=(8, 0))
+        else:
+            self._notice_button = None
+        notice_frame.place(relx=0.5, rely=0.94, anchor="center")
+        self._notice_frame = notice_frame
+        self._notice_after_id = self.window.after(5000 if action_label else 1500, self._clear_notice)
 
     def _clear_notice(self) -> None:
         """Remove the transient status notice."""
         self._notice_after_id = None
-        if self._notice_label is not None and self._notice_label.winfo_exists():
-            self._notice_label.destroy()
+        if hasattr(self, "_notice_frame") and self._notice_frame is not None and self._notice_frame.winfo_exists():
+            self._notice_frame.destroy()
+        self._notice_button = None
         self._notice_label = None
 
     def _replace_note(self, original: Note, updated: Note) -> None:

--- a/src/cogstash/ui/browse.py
+++ b/src/cogstash/ui/browse.py
@@ -12,9 +12,9 @@ import tkinter as tk
 from datetime import datetime, timedelta
 
 from cogstash.search import (
-    _atomic_write,
     DEFAULT_TAG_COLORS,
     Note,
+    _atomic_write,
     delete_note,
     edit_note,
     filter_by_tag,

--- a/src/cogstash/ui/settings.py
+++ b/src/cogstash/ui/settings.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import sys
 import tkinter as tk
 from pathlib import Path
+from tkinter import messagebox
+
+from pynput import keyboard
 
 from cogstash.ui.app import (
     DEFAULT_SMART_TAGS,
@@ -17,6 +20,21 @@ from cogstash.ui.app import (
     save_config,
 )
 from cogstash.ui.install_state import get_startup_shortcut_path
+
+
+def validate_hotkey(value: str) -> tuple[bool, str | None]:
+    """Validate a pynput GlobalHotKeys hotkey string."""
+    hotkey = value.strip()
+    if not hotkey:
+        return False, "Hotkey is required."
+    try:
+        keyboard.HotKey.parse(hotkey)
+    except Exception:
+        return False, (
+            "Enter a valid global hotkey like <ctrl>+<shift>+<space> or "
+            "<ctrl>+<alt>+h."
+        )
+    return True, None
 
 
 def set_launch_at_startup(enable: bool) -> None:
@@ -141,10 +159,35 @@ class SettingsWindow:
         # Section: Hotkey
         tk.Label(frame, text="Hotkey", bg=t["bg"], fg=t["fg"],
                  font=(platform_font(), 11, "bold")).pack(anchor="w", pady=(8, 4))
-        tk.Label(frame, text=self.config.hotkey, bg=t["entry_bg"], fg=t["fg"],
-                 font=(platform_font(), 10), padx=8, pady=4).pack(anchor="w", padx=(8, 0))
-        tk.Label(frame, text="Edit in ~/.cogstash.json to change", bg=t["bg"], fg=t["muted"],
-                 font=(platform_font(), 8)).pack(anchor="w", padx=(8, 0), pady=(2, 0))
+        self.hotkey_var = tk.StringVar(value=self.config.hotkey)
+        hotkey_frame = tk.Frame(frame, bg=t["bg"])
+        hotkey_frame.pack(fill="x", padx=(8, 0))
+        tk.Entry(
+            hotkey_frame,
+            textvariable=self.hotkey_var,
+            bg=t["entry_bg"],
+            fg=t["fg"],
+            insertbackground=t["fg"],
+            relief="flat",
+            font=(platform_font(), 10),
+        ).pack(side="left", fill="x", expand=True, ipady=4)
+        tk.Button(
+            hotkey_frame,
+            text="Test Hotkey",
+            command=self._test_hotkey,
+            bg=t["entry_bg"],
+            fg=t["fg"],
+            relief="flat",
+            font=(platform_font(), 9),
+            cursor="hand2",
+        ).pack(side="left", padx=(8, 0))
+        tk.Label(
+            frame,
+            text="Use pynput format, for example <ctrl>+<shift>+<space>.",
+            bg=t["bg"],
+            fg=t["muted"],
+            font=(platform_font(), 8),
+        ).pack(anchor="w", padx=(8, 0), pady=(2, 0))
         if self.hotkey_warning:
             warning_frame = tk.Frame(
                 frame,
@@ -223,6 +266,12 @@ class SettingsWindow:
 
     def _save_general(self):
         """Save General tab settings to config."""
+        hotkey = self.hotkey_var.get().strip()
+        is_valid, error = validate_hotkey(hotkey)
+        if not is_valid:
+            messagebox.showerror("Invalid Hotkey", error, parent=self.win)
+            return
+        self.config.hotkey = hotkey
         self.config.output_file = Path(self.notes_file_var.get()).expanduser()
         new_launch = self.launch_var.get()
         if new_launch != self.config.launch_at_startup:
@@ -232,6 +281,23 @@ class SettingsWindow:
         self._flash_saved()
         if self.on_config_changed is not None:
             self.on_config_changed(self.config)
+
+    def _test_hotkey(self) -> None:
+        """Validate the currently entered hotkey and explain how it applies."""
+        hotkey = self.hotkey_var.get().strip()
+        is_valid, error = validate_hotkey(hotkey)
+        if not is_valid:
+            messagebox.showerror("Invalid Hotkey", error, parent=self.win)
+            return
+        messagebox.showinfo(
+            "Hotkey Looks Valid",
+            (
+                f"Hotkey syntax looks valid: {hotkey}\n\n"
+                "Save your changes to use it for future launches. If CogStash is already "
+                "running with a different global hotkey, restart the app to rebind capture."
+            ),
+            parent=self.win,
+        )
 
     def _flash_saved(self):
         """Briefly show a 'Saved' indicator."""
@@ -560,6 +626,7 @@ class WizardWindow:
         self.btn_frame.pack(side="right")
 
         self.notes_file_var = tk.StringVar(value=str(config.output_file))
+        self.hotkey_var = tk.StringVar(value=config.hotkey)
         self.selected_theme = tk.StringVar(value=config.theme)
         self.selected_size = tk.StringVar(value=config.window_size)
 
@@ -612,8 +679,35 @@ class WizardWindow:
                      side="left", fill="x", expand=True, ipady=6)
         tk.Button(notes_frame, text="Browse", command=self._browse_notes, bg=t["entry_bg"],
                   fg=t["fg"], relief="flat", font=(platform_font(), 9)).pack(side="left", padx=(8, 0))
-        tk.Label(self.content, text=f"Hotkey: {self.config.hotkey}", bg=t["bg"], fg=t["muted"],
-                 font=(platform_font(), 10)).pack(anchor="w", pady=(16, 0))
+        tk.Label(self.content, text="Choose your capture hotkey", bg=t["bg"], fg=t["fg"],
+                 font=(platform_font(), 11)).pack(anchor="w", pady=(16, 8))
+        hotkey_frame = tk.Frame(self.content, bg=t["bg"])
+        hotkey_frame.pack(fill="x")
+        tk.Entry(
+            hotkey_frame,
+            textvariable=self.hotkey_var,
+            bg=t["entry_bg"],
+            fg=t["fg"],
+            insertbackground=t["fg"],
+            relief="flat",
+            font=(platform_font(), 10),
+        ).pack(side="left", fill="x", expand=True, ipady=6)
+        tk.Button(
+            hotkey_frame,
+            text="Test Hotkey",
+            command=self._test_hotkey,
+            bg=t["entry_bg"],
+            fg=t["fg"],
+            relief="flat",
+            font=(platform_font(), 9),
+        ).pack(side="left", padx=(8, 0))
+        tk.Label(
+            self.content,
+            text="Use pynput format, for example <ctrl>+<shift>+<space>.",
+            bg=t["bg"],
+            fg=t["muted"],
+            font=(platform_font(), 9),
+        ).pack(anchor="w", pady=(8, 0))
 
     def _browse_notes(self):
         """File dialog for notes file."""
@@ -689,7 +783,7 @@ class WizardWindow:
         tk.Label(self.content, text="Quick Tour", bg=t["bg"], fg=t["fg"],
                  font=(platform_font(), 14, "bold")).pack(pady=(8, 12))
         cards = [
-            ("⚡", "Capture", f"Press {self.config.hotkey} anywhere.\nType your thought, press Enter."),
+            ("⚡", "Capture", f"Press {self.hotkey_var.get()} anywhere.\nType your thought, press Enter."),
             ("📋", "Browse", "Right-click the tray icon → Browse Notes\nSearch, filter by tags, mark done."),
             ("💻", "CLI", "cogstash recent — last 10 notes\ncogstash search <query>\ncogstash tags"),
         ]
@@ -716,7 +810,7 @@ class WizardWindow:
             ("Notes", self.notes_file_var.get()),
             ("Theme", self.selected_theme.get()),
             ("Size", self.selected_size.get()),
-            ("Hotkey", self.config.hotkey),
+            ("Hotkey", self.hotkey_var.get()),
         ]
         for label, value in items:
             row = tk.Frame(summary, bg=t["entry_bg"])
@@ -730,6 +824,12 @@ class WizardWindow:
         """Save config and close wizard."""
         from cogstash import __version__
         from cogstash.ui.install_state import is_installed_windows_run
+        hotkey = self.hotkey_var.get().strip()
+        is_valid, error = validate_hotkey(hotkey)
+        if not is_valid:
+            messagebox.showerror("Invalid Hotkey", error, parent=self.win)
+            return
+        self.config.hotkey = hotkey
         self.config.output_file = Path(self.notes_file_var.get()).expanduser()
         self.config.theme = self.selected_theme.get()
         self.config.window_size = self.selected_size.get()
@@ -738,6 +838,22 @@ class WizardWindow:
             self.config.last_seen_installer_version = __version__
         save_config(self.config, self.config_path)
         self._close()
+
+    def _test_hotkey(self) -> None:
+        """Validate the currently entered wizard hotkey and explain next steps."""
+        hotkey = self.hotkey_var.get().strip()
+        is_valid, error = validate_hotkey(hotkey)
+        if not is_valid:
+            messagebox.showerror("Invalid Hotkey", error, parent=self.win)
+            return
+        messagebox.showinfo(
+            "Hotkey Looks Valid",
+            (
+                f"Hotkey syntax looks valid: {hotkey}\n\n"
+                "Finish setup to save it. The new hotkey will be used when CogStash starts."
+            ),
+            parent=self.win,
+        )
 
     def _close(self):
         """Close the wizard and release its modal grab."""

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -143,6 +143,22 @@ def test_cmd_recent_limit(tmp_path, capsys):
     assert "fix login bug" in lines[1]
 
 
+def test_cmd_recent_tag_filter(tmp_path, capsys):
+    """recent --tag should only show matching tagged notes newest first."""
+    f = _make_notes_file(tmp_path)
+    from types import SimpleNamespace
+
+    from cogstash.cli import cmd_recent
+    from cogstash.core import CogStashConfig
+
+    cmd_recent(SimpleNamespace(limit=20, tag="todo"), CogStashConfig(output_file=f))
+    output = capsys.readouterr().out
+
+    assert "buy milk" in output
+    assert "redesign dashboard" not in output
+    assert "fix login bug" not in output
+
+
 def test_cmd_recent_empty(tmp_path, capsys):
     """Empty/missing file shows 'No notes found.' message."""
     f = tmp_path / "cogstash.md"
@@ -154,6 +170,20 @@ def test_cmd_recent_empty(tmp_path, capsys):
     cmd_recent(SimpleNamespace(limit=20), CogStashConfig(output_file=f))
     output = capsys.readouterr().out
     assert "No notes found." in output
+
+
+def test_cmd_recent_tag_filter_no_match(tmp_path, capsys):
+    """recent --tag with no matches should report that no notes were found."""
+    f = _make_notes_file(tmp_path)
+    from types import SimpleNamespace
+
+    from cogstash.cli import cmd_recent
+    from cogstash.core import CogStashConfig
+
+    cmd_recent(SimpleNamespace(limit=20, tag="idea"), CogStashConfig(output_file=f))
+    output = capsys.readouterr().out
+
+    assert "No notes found for tag #idea." in output
 
 
 def test_cmd_search_match(tmp_path, capsys):
@@ -172,6 +202,26 @@ def test_cmd_search_match(tmp_path, capsys):
     assert "buy milk" in lines[0]
 
 
+def test_cmd_search_tag_filter(tmp_path, capsys):
+    """search --tag should keep only matches within the requested tag scope."""
+    f = _make_notes_file(tmp_path)
+    from types import SimpleNamespace
+
+    from cogstash.cli import cmd_search
+    from cogstash.core import CogStashConfig
+
+    cmd_search(SimpleNamespace(query="note", limit=20, tag=None), CogStashConfig(output_file=f))
+    unfiltered = capsys.readouterr().out
+
+    cmd_search(SimpleNamespace(query="note", limit=20, tag="todo"), CogStashConfig(output_file=f))
+    filtered = capsys.readouterr().out
+
+    assert "old note" in unfiltered
+    assert "buy milk" not in filtered
+    assert "old note" not in filtered
+    assert "No matching notes for tag #todo." in filtered
+
+
 def test_cmd_search_no_match(tmp_path, capsys):
     """No matches shows 'No matching notes.' message."""
     f = _make_notes_file(tmp_path)
@@ -183,6 +233,28 @@ def test_cmd_search_no_match(tmp_path, capsys):
     cmd_search(SimpleNamespace(query="nonexistent xyz", limit=20), CogStashConfig(output_file=f))
     output = capsys.readouterr().out
     assert "No matching notes." in output
+
+
+def test_cmd_export_tag_filter_json_content(tmp_path, capsys):
+    """export --tag should only write matching notes to the export file."""
+    import json
+    from types import SimpleNamespace
+
+    from cogstash.cli import cmd_export
+    from cogstash.core import CogStashConfig
+
+    f = _make_notes_file(tmp_path)
+    out_path = tmp_path / "todo-notes.json"
+
+    cmd_export(
+        SimpleNamespace(format="json", output=str(out_path), tag="todo"),
+        CogStashConfig(output_file=f),
+    )
+
+    data = json.loads(out_path.read_text(encoding="utf-8"))
+    assert len(data) == 1
+    assert data[0]["tags"] == ["todo"]
+    assert "buy milk" in data[0]["text"]
 
 
 def test_cmd_tags_counts(tmp_path, capsys):

--- a/tests/ui/test_browse_extended.py
+++ b/tests/ui/test_browse_extended.py
@@ -361,6 +361,64 @@ def test_browse_delete_note(tmp_path, tk_root):
 
 
 @needs_display
+def test_browse_delete_confirmation_uses_multiline_preview(tmp_path, tk_root):
+    """Delete confirmation should show a readable multiline preview, not a terse one-liner."""
+    f = tmp_path / "cogstash.md"
+    f.write_text(
+        "- [2026-03-26 14:30] first line of a longer note\n"
+        "  second line with extra context\n"
+        "  third line for preview\n",
+        encoding="utf-8",
+    )
+
+    from cogstash.app import CogStashConfig
+    from cogstash.browse import BrowseWindow
+
+    win = BrowseWindow(tk_root, CogStashConfig(output_file=f))
+    note = win._all_notes[0]
+
+    with patch("tkinter.messagebox.askyesno", return_value=False) as confirm_mock:
+        win._on_delete(note)
+
+    args, kwargs = confirm_mock.call_args
+    message = kwargs.get("message") if kwargs else None
+    if message is None:
+        message = args[1]
+    assert "Delete this note?" in message
+    assert "Preview:" in message
+    assert "second line with extra context" in message
+    win.window.destroy()
+
+
+@needs_display
+def test_browse_delete_undo_restores_note(tmp_path, tk_root):
+    """Undo should restore the most recently deleted note during the session."""
+    f = tmp_path / "cogstash.md"
+    f.write_text(
+        "- [2026-03-26 14:30] first note\n"
+        "- [2026-03-26 15:00] second note\n",
+        encoding="utf-8",
+    )
+
+    from cogstash.app import CogStashConfig
+    from cogstash.browse import BrowseWindow
+
+    win = BrowseWindow(tk_root, CogStashConfig(output_file=f))
+    note = win._all_notes[0]
+
+    with patch("tkinter.messagebox.askyesno", return_value=True):
+        win._on_delete(note)
+
+    assert len(win._all_notes) == 1
+
+    win._undo_delete()
+
+    assert len(win._all_notes) == 2
+    assert "first note" in f.read_text(encoding="utf-8")
+    win.window.destroy()
+
+
+@needs_display
 def test_browse_copy_shows_non_blocking_notice(tmp_path, tk_root):
     """Copy action should acknowledge success without a modal dialog."""
     f = tmp_path / "cogstash.md"

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -99,6 +100,74 @@ def test_settings_save_appearance_applies_changes_immediately(tk_root, tmp_path)
 
 
 @needs_display
+def test_settings_save_general_persists_hotkey_and_notifies_app(tk_root, tmp_path):
+    """Saving General should persist an edited hotkey and notify the app."""
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
+
+    config_path = tmp_path / "test.json"
+    calls = []
+    sw = SettingsWindow(
+        tk_root,
+        CogStashConfig(),
+        config_path,
+        on_config_changed=lambda config: calls.append(config.hotkey),
+    )
+    sw.hotkey_var.set("<ctrl>+<alt>+h")
+
+    sw._save_general()
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert sw.config.hotkey == "<ctrl>+<alt>+h"
+    assert data["hotkey"] == "<ctrl>+<alt>+h"
+    assert calls == ["<ctrl>+<alt>+h"]
+    sw.win.destroy()
+
+
+@needs_display
+def test_settings_invalid_hotkey_shows_error_and_does_not_save(tk_root, tmp_path):
+    """Saving an invalid hotkey should show an error and leave config untouched."""
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
+
+    config_path = tmp_path / "test.json"
+    sw = SettingsWindow(tk_root, CogStashConfig(), config_path)
+    sw.hotkey_var.set("not-a-hotkey")
+
+    with patch("tkinter.messagebox.showerror") as error_mock:
+        sw._save_general()
+
+    assert sw.config.hotkey == "<ctrl>+<shift>+<space>"
+    assert not config_path.exists()
+    error_mock.assert_called_once()
+    sw.win.destroy()
+
+
+@needs_display
+def test_settings_test_hotkey_shows_success_for_valid_input(tk_root, tmp_path, monkeypatch):
+    """Test Hotkey should confirm valid hotkey syntax and guidance."""
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
+
+    sw = SettingsWindow(tk_root, CogStashConfig(), tmp_path / "test.json")
+    sw.hotkey_var.set("<ctrl>+<alt>+h")
+
+    class FakeHotKey:
+        @staticmethod
+        def parse(value):
+            assert value == "<ctrl>+<alt>+h"
+            return ["parsed"]
+
+    monkeypatch.setattr("cogstash.ui.settings.keyboard.HotKey", FakeHotKey)
+
+    with patch("tkinter.messagebox.showinfo") as info_mock:
+        sw._test_hotkey()
+
+    info_mock.assert_called_once()
+    sw.win.destroy()
+
+
+@needs_display
 def test_wizard_saves_config(tk_root, tmp_path):
     """Wizard writes valid config with all fields when completed."""
     from cogstash.ui.app import CogStashConfig
@@ -113,6 +182,24 @@ def test_wizard_saves_config(tk_root, tmp_path):
     assert "theme" in data
     assert "last_seen_version" in data
     assert data["last_seen_version"] != ""
+    wiz.win.destroy()
+
+
+@needs_display
+def test_wizard_finish_persists_edited_hotkey(tk_root, tmp_path):
+    """Finishing the wizard should persist an edited hotkey."""
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.settings import WizardWindow
+
+    config = CogStashConfig()
+    config_path = tmp_path / ".cogstash.json"
+    wiz = WizardWindow(tk_root, config, config_path)
+    wiz.hotkey_var.set("<ctrl>+<alt>+h")
+
+    wiz._finish()
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert data["hotkey"] == "<ctrl>+<alt>+h"
     wiz.win.destroy()
 
 


### PR DESCRIPTION
## Summary
- add in-app hotkey editing and validation in Settings and the first-run wizard
- add safer Browse deletion with multiline preview and session-level undo
- add tag-scoped CLI workflows plus clearer release/install guidance

## Test Plan
- python -m pytest tests/ui/test_settings.py tests/ui/test_settings_extended.py tests/ui/test_browse.py tests/ui/test_browse_extended.py tests/cli/test_cli.py --basetemp G:\\Projects\\2026\\cool_projects\\CogStash\\.pytest-tmp-issue11 -q