### PR TITLE
refactor: tighten post-split architecture boundaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,21 +161,49 @@ jobs:
         shell: bash
       - name: Archive onedir bundle (Windows)
         if: matrix.os == 'windows-latest'
-        run: Compress-Archive -Path dist/CogStash-*-onedir -DestinationPath dist/CogStash-${{ github.ref_name }}-windows.zip
-        shell: pwsh
+        run: |
+          import subprocess
+          import sys
+
+          sys.path.insert(0, "scripts")
+          from _artifacts import get_release_archive_name
+
+          archive_name = get_release_archive_name(tag="${{ github.ref_name }}", platform_suffix="windows")
+          subprocess.run(["powershell", "-Command", f"Compress-Archive -Path dist/CogStash-*-onedir -DestinationPath dist/{archive_name}"], check=True)
+        shell: python
       - name: Archive onedir bundle (macOS)
         if: matrix.os == 'macos-latest'
-        run: cd dist && zip -r CogStash-${{ github.ref_name }}-macos.zip CogStash-*-onedir
-        shell: bash
+        run: |
+          import subprocess
+          import sys
+
+          sys.path.insert(0, "scripts")
+          from _artifacts import get_release_archive_name
+
+          archive_name = get_release_archive_name(tag="${{ github.ref_name }}", platform_suffix="macos")
+          subprocess.run(["bash", "-lc", f"cd dist && zip -r {archive_name} CogStash-*-onedir"], check=True)
+        shell: python
       - name: Archive onedir bundle (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: cd dist && tar -czf CogStash-${{ github.ref_name }}-linux.tar.gz CogStash-*-onedir
-        shell: bash
+        run: |
+          import subprocess
+          import sys
+
+          sys.path.insert(0, "scripts")
+          from _artifacts import get_release_archive_name
+
+          archive_name = get_release_archive_name(tag="${{ github.ref_name }}", platform_suffix="linux")
+          subprocess.run(["bash", "-lc", f"cd dist && tar -czf {archive_name} CogStash-*-onedir"], check=True)
+        shell: python
       - name: Rename onefile artifacts
         run: |
           import glob
           import os
+          import sys
           from pathlib import Path
+
+          sys.path.insert(0, "scripts")
+          from _artifacts import get_executable_name
 
           suffix = "${{ matrix.artifact_suffix }}"
           ext = "${{ matrix.exe_ext }}"
@@ -191,8 +219,8 @@ jobs:
           if not cli_candidates:
               raise SystemExit("Could not find CLI onefile artifact to rename")
 
-          ui_target = dist_dir / f"CogStash-{version}-{suffix}{ext}"
-          cli_target = dist_dir / f"CogStash-CLI-{version}-{suffix}{ext}"
+          ui_target = dist_dir / f"{get_executable_name(target='ui', bundle_mode='onefile', version=version)}-{suffix}{ext}"
+          cli_target = dist_dir / f"{get_executable_name(target='cli', bundle_mode='onefile', version=version)}-{suffix}{ext}"
           ui_candidates[0].replace(ui_target)
           cli_candidates[0].replace(cli_target)
         shell: python

--- a/docs/superpowers/plans/2026-04-22-ui-queue-thread-lifecycle.md
+++ b/docs/superpowers/plans/2026-04-22-ui-queue-thread-lifecycle.md
@@ -1,0 +1,522 @@
+# UI Queue And Thread Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract a dedicated UI runtime module that owns queue commands, tray and hotkey wiring, queue dispatch, and runtime shutdown while preserving existing app behavior.
+
+**Architecture:** Keep `src/cogstash/ui/app.py` focused on Tk UI behavior and startup flow, and introduce `src/cogstash/ui/app_runtime.py` as the single boundary for cross-thread command flow. The new module will define the command contract, expose queue dispatch helpers, and return handles for startup and shutdown so `main()` no longer open-codes lifecycle behavior.
+
+**Tech Stack:** Python, Tkinter, `queue`, `threading`, `pynput`, `pystray`, `pytest`, `monkeypatch`
+
+---
+
+## File Map
+
+- Create: `src/cogstash/ui/app_runtime.py`
+  Purpose: own command definitions, queue drain/dispatch, tray startup, hotkey startup, and runtime cleanup handles.
+- Modify: `src/cogstash/ui/app.py`
+  Purpose: delegate queue polling and runtime startup/shutdown to `app_runtime.py`, keeping only UI behavior and startup warning UX.
+- Create: `tests/ui/test_app_runtime.py`
+  Purpose: focused contract tests for queue dispatch, tray/hotkey enqueue behavior, startup results, and safe cleanup.
+- Modify: `tests/ui/test_app.py`
+  Purpose: update startup tests to assert delegation into `app_runtime.py` and preserve current hotkey warning/startup behavior.
+
+### Task 1: Add focused runtime-contract tests
+
+**Files:**
+- Create: `tests/ui/test_app_runtime.py`
+
+- [ ] **Step 1: Write the failing queue-dispatch tests**
+
+```python
+from __future__ import annotations
+
+import queue
+
+import cogstash.ui.app_runtime as runtime
+
+
+def test_drain_queue_dispatches_supported_commands():
+    app_queue: queue.Queue[runtime.AppCommand] = queue.Queue()
+    app_queue.put(runtime.AppCommand.SHOW)
+    app_queue.put(runtime.AppCommand.BROWSE)
+    app_queue.put(runtime.AppCommand.SETTINGS)
+    app_queue.put(runtime.AppCommand.QUIT)
+
+    events: list[str] = []
+
+    should_continue = runtime.drain_app_queue(
+        app_queue,
+        on_show=lambda: events.append("show"),
+        on_browse=lambda: events.append("browse"),
+        on_settings=lambda: events.append("settings"),
+        on_quit=lambda: events.append("quit"),
+    )
+
+    assert events == ["show", "browse", "settings", "quit"]
+    assert should_continue is False
+
+
+def test_drain_queue_ignores_unknown_commands():
+    app_queue: queue.Queue[object] = queue.Queue()
+    app_queue.put("UNKNOWN")
+
+    events: list[str] = []
+
+    should_continue = runtime.drain_app_queue(
+        app_queue,
+        on_show=lambda: events.append("show"),
+        on_browse=lambda: events.append("browse"),
+        on_settings=lambda: events.append("settings"),
+        on_quit=lambda: events.append("quit"),
+    )
+
+    assert events == []
+    assert should_continue is True
+
+
+def test_drain_queue_handles_empty_queue():
+    app_queue: queue.Queue[runtime.AppCommand] = queue.Queue()
+
+    should_continue = runtime.drain_app_queue(
+        app_queue,
+        on_show=lambda: None,
+        on_browse=lambda: None,
+        on_settings=lambda: None,
+        on_quit=lambda: None,
+    )
+
+    assert should_continue is True
+```
+
+- [ ] **Step 2: Run the runtime queue tests to verify they fail**
+
+Run: `python -m pytest tests/ui/test_app_runtime.py -k "drain_queue" -q`
+Expected: FAIL with `ModuleNotFoundError` for `cogstash.ui.app_runtime` or missing `AppCommand`/`drain_app_queue`.
+
+- [ ] **Step 3: Write the failing startup and cleanup tests**
+
+```python
+from __future__ import annotations
+
+import queue
+from types import SimpleNamespace
+
+import cogstash.ui.app_runtime as runtime
+
+
+def test_register_hotkey_listener_enqueues_show_command(monkeypatch):
+    app_queue: queue.Queue[runtime.AppCommand] = queue.Queue()
+
+    created_mappings: list[dict] = []
+
+    class FakeListener:
+        def __init__(self, mapping):
+            created_mappings.append(mapping)
+            self.started = False
+
+        def start(self):
+            self.started = True
+
+    monkeypatch.setattr(runtime.keyboard, "GlobalHotKeys", FakeListener)
+
+    listener = runtime.start_hotkey_listener(app_queue, "<ctrl>+<alt>+space")
+
+    hotkey_callback = created_mappings[0]["<ctrl>+<alt>+space"]
+    hotkey_callback()
+
+    assert listener.started is True
+    assert app_queue.get_nowait() is runtime.AppCommand.SHOW
+
+
+def test_shutdown_runtime_stops_listener_and_tray():
+    stopped: list[str] = []
+
+    runtime.shutdown_runtime(
+        runtime.AppRuntimeHandles(
+            tray_icon=SimpleNamespace(stop=lambda: stopped.append("tray")),
+            hotkey_listener=SimpleNamespace(stop=lambda: stopped.append("hotkey")),
+        )
+    )
+
+    assert stopped == ["tray", "hotkey"]
+
+
+def test_shutdown_runtime_tolerates_missing_handles():
+    runtime.shutdown_runtime(runtime.AppRuntimeHandles())
+```
+
+- [ ] **Step 4: Run the startup and cleanup tests to verify they fail**
+
+Run: `python -m pytest tests/ui/test_app_runtime.py -k "hotkey or shutdown_runtime" -q`
+Expected: FAIL because `start_hotkey_listener`, `shutdown_runtime`, or `AppRuntimeHandles` are undefined.
+
+- [ ] **Step 5: Commit the red tests checkpoint**
+
+```bash
+git add tests/ui/test_app_runtime.py
+git commit -m "test: define app runtime contract"
+```
+
+### Task 2: Implement the runtime boundary module
+
+**Files:**
+- Create: `src/cogstash/ui/app_runtime.py`
+- Test: `tests/ui/test_app_runtime.py`
+
+- [ ] **Step 1: Create command types, handles, and queue drain implementation**
+
+```python
+from __future__ import annotations
+
+import logging
+import queue
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable
+
+from pynput import keyboard
+
+logger = logging.getLogger("cogstash")
+
+
+class AppCommand(str, Enum):
+    SHOW = "SHOW"
+    BROWSE = "BROWSE"
+    SETTINGS = "SETTINGS"
+    QUIT = "QUIT"
+
+
+@dataclass
+class AppRuntimeHandles:
+    tray_icon: object | None = None
+    hotkey_listener: object | None = None
+
+
+def enqueue_command(app_queue: queue.Queue[AppCommand], command: AppCommand) -> None:
+    app_queue.put(command)
+
+
+def drain_app_queue(
+    app_queue: queue.Queue[object],
+    *,
+    on_show: Callable[[], None],
+    on_browse: Callable[[], None],
+    on_settings: Callable[[], None],
+    on_quit: Callable[[], None],
+) -> bool:
+    while True:
+        try:
+            command = app_queue.get_nowait()
+        except queue.Empty:
+            return True
+
+        if command is AppCommand.SHOW:
+            on_show()
+        elif command is AppCommand.BROWSE:
+            on_browse()
+        elif command is AppCommand.SETTINGS:
+            on_settings()
+        elif command is AppCommand.QUIT:
+            on_quit()
+            return False
+        else:
+            logger.warning("Ignoring unknown app command: %r", command)
+```
+
+- [ ] **Step 2: Add tray and hotkey startup helpers plus cleanup**
+
+```python
+from pathlib import Path
+import sys
+import threading
+
+from cogstash.core import CogStashConfig
+from cogstash.ui import windows_runtime
+
+
+def start_hotkey_listener(
+    app_queue: queue.Queue[AppCommand],
+    hotkey: str,
+):
+    listener = keyboard.GlobalHotKeys(
+        {hotkey: lambda: enqueue_command(app_queue, AppCommand.SHOW)}
+    )
+    listener.start()
+    return listener
+
+
+def start_tray_icon(
+    app_queue: queue.Queue[AppCommand],
+    config: CogStashConfig,
+    *,
+    themes: dict[str, dict[str, str]],
+):
+    try:
+        import pystray
+        from PIL import Image, ImageDraw, ImageFont
+    except ImportError:
+        logger.warning("pystray or Pillow not installed — skipping tray icon")
+        return None
+
+    theme = themes[config.theme]
+
+    def open_notes():
+        windows_runtime.open_target_in_shell(str(config.output_file))
+
+    def browse_notes():
+        enqueue_command(app_queue, AppCommand.BROWSE)
+
+    def open_settings():
+        enqueue_command(app_queue, AppCommand.SETTINGS)
+
+    def quit_app(icon):
+        icon.stop()
+        enqueue_command(app_queue, AppCommand.QUIT)
+
+    # keep existing icon-generation logic unchanged here
+    icon = pystray.Icon("cogstash", img, "CogStash", menu)
+    threading.Thread(target=icon.run, daemon=True).start()
+    return icon
+
+
+def start_runtime(
+    app_queue: queue.Queue[AppCommand],
+    config: CogStashConfig,
+    *,
+    themes: dict[str, dict[str, str]],
+) -> AppRuntimeHandles:
+    return AppRuntimeHandles(
+        tray_icon=start_tray_icon(app_queue, config, themes=themes),
+        hotkey_listener=None,
+    )
+
+
+def shutdown_runtime(handles: AppRuntimeHandles) -> None:
+    if handles.tray_icon is not None:
+        handles.tray_icon.stop()
+    if handles.hotkey_listener is not None:
+        handles.hotkey_listener.stop()
+```
+
+- [ ] **Step 3: Run the focused runtime tests and make them pass**
+
+Run: `python -m pytest tests/ui/test_app_runtime.py -q`
+Expected: PASS
+
+- [ ] **Step 4: Commit the runtime boundary module**
+
+```bash
+git add src/cogstash/ui/app_runtime.py tests/ui/test_app_runtime.py
+git commit -m "feat: extract app runtime lifecycle contract"
+```
+
+### Task 3: Refactor `app.py` to delegate queue and runtime lifecycle
+
+**Files:**
+- Modify: `src/cogstash/ui/app.py`
+- Test: `tests/ui/test_app.py`
+
+- [ ] **Step 1: Replace raw queue usage in `CogStash` with runtime delegation**
+
+```python
+from cogstash.ui import app_runtime, windows_runtime
+
+
+class CogStash:
+    def __init__(self, root: tk.Tk, config: CogStashConfig, config_path: Path | None = None):
+        ...
+        self.queue: queue.Queue[app_runtime.AppCommand] = queue.Queue()
+        ...
+
+    def poll_queue(self):
+        should_continue = app_runtime.drain_app_queue(
+            self.queue,
+            on_show=self.show_window,
+            on_browse=self._open_browse,
+            on_settings=self._open_settings,
+            on_quit=self.root.quit,
+        )
+        if should_continue:
+            self.root.after(100, self.poll_queue)
+```
+
+- [ ] **Step 2: Move tray and hotkey startup/shutdown in `main()` behind runtime helpers**
+
+```python
+def main():
+    ...
+    app = CogStash(root, config)
+    app.config_path = config_path
+
+    runtime_handles = app_runtime.start_runtime(
+        app.queue,
+        config,
+        themes=THEMES,
+    )
+
+    try:
+        runtime_handles.hotkey_listener = app_runtime.start_hotkey_listener(
+            app.queue,
+            config.hotkey,
+        )
+    except Exception:
+        app.hotkey_warning = _build_hotkey_failure_warning(config)
+        logger.error("Failed to register global hotkey %s", config.hotkey, exc_info=True)
+        ...
+
+    try:
+        root.mainloop()
+    except KeyboardInterrupt:
+        safe_print("\nCogStash stopped.")
+    finally:
+        app_runtime.shutdown_runtime(runtime_handles)
+        instance_guard.close()
+```
+
+- [ ] **Step 3: Remove or collapse obsolete lifecycle helpers from `app.py`**
+
+```python
+# delete create_tray_icon() from app.py entirely after its tests move to app_runtime
+
+def configure_dpi() -> None:
+    """Compatibility forwarder for UI Windows runtime DPI setup."""
+    windows_runtime.configure_dpi()
+```
+
+- [ ] **Step 4: Update startup tests to assert runtime delegation**
+
+```python
+def test_app_main_continues_startup_after_hotkey_registration_failure(monkeypatch, tmp_path):
+    import cogstash.ui.app as app_mod
+    import cogstash.ui.app_runtime as runtime_mod
+
+    started_handles = runtime_mod.AppRuntimeHandles()
+
+    monkeypatch.setattr(app_mod.app_runtime, "start_runtime", lambda *_a, **_k: started_handles)
+    monkeypatch.setattr(
+        app_mod.app_runtime,
+        "start_hotkey_listener",
+        lambda *_a, **_k: (_ for _ in ()).throw(OSError("hotkey already in use")),
+    )
+    monkeypatch.setattr(app_mod.app_runtime, "shutdown_runtime", lambda _handles: None)
+
+    _config, output, warnings, created_apps = _run_main_startup(monkeypatch, tmp_path, listener_cls=None)
+
+    assert len(warnings) == 1
+    assert "CogStash is running." in output
+    assert created_apps == [True]
+```
+
+- [ ] **Step 5: Run the app startup tests for delegation behavior**
+
+Run: `python -m pytest tests/ui/test_app.py -k "startup or hotkey_warning or duplicate_instance" -q`
+Expected: PASS
+
+- [ ] **Step 6: Commit the app delegation refactor**
+
+```bash
+git add src/cogstash/ui/app.py tests/ui/test_app.py
+git commit -m "refactor: delegate ui runtime lifecycle"
+```
+
+### Task 4: Verify queue behavior at the app seam
+
+**Files:**
+- Modify: `tests/ui/test_app.py`
+- Modify: `tests/ui/test_settings_extended.py`
+
+- [ ] **Step 1: Add a focused app poll test that proves the runtime dispatcher is used**
+
+```python
+@needs_display
+def test_poll_queue_delegates_to_app_runtime(monkeypatch, tk_root):
+    import cogstash.ui.app as app_mod
+
+    app = app_mod.CogStash(tk_root, app_mod.CogStashConfig())
+    called: list[object] = []
+
+    def fake_drain(app_queue, **callbacks):
+        called.append(app_queue)
+        callbacks["on_show"]()
+        return False
+
+    monkeypatch.setattr(app_mod.app_runtime, "drain_app_queue", fake_drain)
+    app.show_window = lambda: called.append("show")
+
+    app.poll_queue()
+
+    assert called[0] is app.queue
+    assert called[1] == "show"
+```
+
+- [ ] **Step 2: Update any queue message tests to use `AppCommand` instead of raw strings where appropriate**
+
+```python
+@needs_display
+def test_settings_queue_message(tk_root):
+    from cogstash.app import CogStash, CogStashConfig
+    from cogstash.ui.app_runtime import AppCommand
+
+    app = CogStash(tk_root, CogStashConfig())
+    app.queue.put(AppCommand.SETTINGS)
+    opened = []
+    app._open_settings = lambda: opened.append(True)
+
+    app.poll_queue()
+
+    assert opened == [True]
+```
+
+- [ ] **Step 3: Run the queue-behavior seam tests**
+
+Run: `python -m pytest tests/ui/test_app.py tests/ui/test_settings_extended.py -k "poll_queue or settings_queue_message" -q`
+Expected: PASS
+
+- [ ] **Step 4: Commit the seam-level queue test updates**
+
+```bash
+git add tests/ui/test_app.py tests/ui/test_settings_extended.py
+git commit -m "test: cover runtime queue delegation"
+```
+
+### Task 5: Full verification and finish
+
+**Files:**
+- Verify: `src/cogstash/ui/app_runtime.py`
+- Verify: `src/cogstash/ui/app.py`
+- Verify: `tests/ui/test_app_runtime.py`
+- Verify: `tests/ui/test_app.py`
+- Verify: `tests/ui/test_settings_extended.py`
+
+- [ ] **Step 1: Run lint on changed source and tests**
+
+Run: `python -m ruff check src/cogstash/ui/app.py src/cogstash/ui/app_runtime.py tests/ui/test_app.py tests/ui/test_app_runtime.py tests/ui/test_settings_extended.py`
+Expected: PASS with no diagnostics.
+
+- [ ] **Step 2: Run the focused verification suite**
+
+Run: `python -m pytest tests/ui/test_app_runtime.py tests/ui/test_app.py tests/ui/test_settings_extended.py tests/ui/test_app_compat.py tests/cli/test_main.py tests/test_build_installer.py -q`
+Expected: PASS
+
+- [ ] **Step 3: Inspect diff before final commit**
+
+Run: `git diff -- src/cogstash/ui/app.py src/cogstash/ui/app_runtime.py tests/ui/test_app.py tests/ui/test_app_runtime.py tests/ui/test_settings_extended.py`
+Expected: only the planned runtime-boundary and test changes.
+
+- [ ] **Step 4: Commit the verified slice if any verification fixes were needed**
+
+```bash
+git add src/cogstash/ui/app.py src/cogstash/ui/app_runtime.py tests/ui/test_app.py tests/ui/test_app_runtime.py tests/ui/test_settings_extended.py
+git commit -m "test: finalize ui runtime lifecycle coverage"
+```
+
+- [ ] **Step 5: Prepare handoff notes**
+
+```text
+Summarize:
+- new runtime contract module added
+- app.py now delegates queue drain and lifecycle startup/shutdown
+- tray and hotkey wiring use the shared command contract
+- verification commands and results
+```

--- a/docs/superpowers/plans/2026-04-22-windows-responsibility-boundaries.md
+++ b/docs/superpowers/plans/2026-04-22-windows-responsibility-boundaries.md
@@ -1,0 +1,151 @@
+# Windows Responsibility Boundaries Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate UI-only Windows runtime helpers into a dedicated owner while preserving the existing split between CLI Windows helpers, UI mutex/process helpers, installer-state readers, and installer-time side effects.
+
+**Architecture:** Keep `cogstash.cli.windows` focused on CLI console attach, keep `cogstash.ui.windows` focused on single-instance primitives, keep `cogstash.ui.install_state` focused on installer-derived runtime state, and introduce `cogstash.ui.windows_runtime` for GUI-runtime Windows actions currently embedded in `ui.app` and `ui.settings`. Preserve behavior and compatibility while moving the implementation seams to clearer owners.
+
+**Tech Stack:** Python 3.9+, tkinter, pytest, ruff
+
+---
+
+## File / Artifact Map
+
+- Create: `src/cogstash/ui/windows_runtime.py`
+  - own GUI-runtime Windows helpers such as DPI setup, shell/open-target behavior, and startup-script mutation
+- Modify: `src/cogstash/ui/app.py`
+  - delegate Windows runtime actions through `ui.windows_runtime`
+- Modify: `src/cogstash/ui/settings.py`
+  - delegate startup-script mutation and shell opening through `ui.windows_runtime`
+- Modify: `tests/ui/test_app.py`
+  - lock DPI delegation to `ui.windows_runtime`
+- Modify: `tests/ui/test_settings.py`
+  - lock startup-toggle and link-opening delegation to `ui.windows_runtime`
+- Verify: `tests/ui/test_app_compat.py`
+  - existing compatibility coverage remains valid
+- Verify: `tests/cli/test_main.py`
+  - CLI Windows bootstrap remains unchanged
+- Verify: `tests/test_build_installer.py`
+  - installer ownership contract remains unchanged
+- Reference: `docs/superpowers/specs/2026-04-22-windows-responsibility-boundaries-design.md`
+  - approved scope for issue `#23`
+
+## Baseline Verification
+
+Before implementation starts, run:
+
+```bash
+python -m pytest tests/ui/test_app.py tests/ui/test_settings.py -q
+```
+
+Expected: PASS on the current branch before adding new ownership tests.
+
+## Task 1: Lock the new Windows-runtime ownership with failing tests
+
+**Files:**
+- Modify: `tests/ui/test_app.py`
+- Modify: `tests/ui/test_settings.py`
+
+- [ ] **Step 1: Add a failing app startup delegation test**
+
+Add a test proving `app.main()` uses `cogstash.ui.windows_runtime.configure_dpi()` rather than owning the DPI implementation inline.
+
+- [ ] **Step 2: Add a failing settings startup-toggle delegation test**
+
+Add a test proving `SettingsWindow._save_general()` delegates startup mutation to `cogstash.ui.windows_runtime.set_launch_at_startup()`.
+
+- [ ] **Step 3: Add a failing settings shell-open delegation test**
+
+Add a test proving `SettingsWindow._open_link()` delegates to `cogstash.ui.windows_runtime.open_target_in_shell()`.
+
+- [ ] **Step 4: Run the focused red tests**
+
+Run:
+
+```bash
+python -m pytest tests/ui/test_app.py -k windows_runtime -q
+python -m pytest tests/ui/test_settings.py -k windows_runtime -q
+```
+
+Expected: FAIL because `cogstash.ui.windows_runtime` does not exist yet.
+
+## Task 2: Introduce `ui.windows_runtime` and wire app/settings through it
+
+**Files:**
+- Create: `src/cogstash/ui/windows_runtime.py`
+- Modify: `src/cogstash/ui/app.py`
+- Modify: `src/cogstash/ui/settings.py`
+
+- [ ] **Step 1: Add the new owner module**
+
+Create `src/cogstash/ui/windows_runtime.py` with these helpers:
+
+- `configure_dpi()`
+- `open_target_in_shell(target: str)`
+- `set_launch_at_startup(enable: bool)`
+
+- [ ] **Step 2: Delegate app Windows runtime behavior**
+
+Update `src/cogstash/ui/app.py` so:
+
+- DPI setup goes through `ui.windows_runtime`
+- tray “Open notes” behavior uses `open_target_in_shell()`
+- any retained local helper is only a thin forwarder, not the real owner
+
+- [ ] **Step 3: Delegate settings Windows runtime behavior**
+
+Update `src/cogstash/ui/settings.py` so:
+
+- startup toggle writes/removes the script through `ui.windows_runtime.set_launch_at_startup()`
+- About/settings link opening goes through `ui.windows_runtime.open_target_in_shell()`
+
+- [ ] **Step 4: Run the focused ownership tests**
+
+Run:
+
+```bash
+python -m pytest tests/ui/test_app.py -k windows_runtime -q
+python -m pytest tests/ui/test_settings.py -k windows_runtime -q
+```
+
+Expected: PASS.
+
+## Task 3: Verify the full Windows-responsibility surface
+
+**Files:**
+- Verify: `tests/ui/test_app.py`
+- Verify: `tests/ui/test_settings.py`
+- Verify: `tests/ui/test_app_compat.py`
+- Verify: `tests/cli/test_main.py`
+- Verify: `tests/test_build_installer.py`
+
+- [ ] **Step 1: Run the broader regression set**
+
+Run:
+
+```bash
+python -m pytest tests/ui/test_app.py tests/ui/test_settings.py tests/ui/test_app_compat.py tests/cli/test_main.py tests/test_build_installer.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run lint**
+
+Run:
+
+```bash
+python -m ruff check src/ tests/
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Review the diff for boundary correctness**
+
+Confirm the branch now reflects:
+
+- `cli.windows` for CLI console attach
+- `ui.windows` for GUI mutex/process primitives
+- `ui.install_state` for installer-derived runtime state
+- `ui.windows_runtime` for GUI-runtime Windows actions
+- installer-side artifact writes still owned by `installer/windows/CogStash.iss`

--- a/docs/superpowers/plans/2026-04-22-wrapper-boundaries-and-direct-imports.md
+++ b/docs/superpowers/plans/2026-04-22-wrapper-boundaries-and-direct-imports.md
@@ -1,0 +1,209 @@
+# Wrapper Boundaries and Direct Imports Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make root-level wrapper modules explicitly compatibility-only while migrating internal code and non-compatibility tests to direct owning-layer imports.
+
+**Architecture:** Keep the external wrapper files in place, but stop relying on them for normal internal behavior. The implementation should move note/config imports toward `cogstash.core` and UI implementation imports toward `cogstash.ui.*`, while preserving wrapper coverage in dedicated compatibility tests such as `tests/ui/test_app_compat.py`.
+
+**Tech Stack:** Python 3.9+, tkinter, pytest, ruff
+
+---
+
+## File / Artifact Map
+
+- Modify: `src/cogstash/ui/browse.py`
+  - replace `cogstash.search` imports with owning `cogstash.core` / `cogstash.core.notes` imports
+  - keep true UI-owned imports in `cogstash.ui.app`
+- Modify: `src/cogstash/ui/settings.py`
+  - move clearly core-owned imports off `cogstash.ui.app`
+  - keep true UI-owned imports in `cogstash.ui.app`
+- Modify: `src/cogstash/app.py`
+  - add compatibility-shim module docstring
+- Modify: `src/cogstash/browse.py`
+  - add compatibility-shim module docstring
+- Modify: `src/cogstash/settings.py`
+  - add compatibility-shim module docstring
+- Modify: `src/cogstash/search.py`
+  - add compatibility-shim module docstring
+- Modify: `src/cogstash/_windows.py`
+  - add compatibility-shim module docstring
+- Modify: `tests/core/test_search.py`
+  - migrate implementation tests to `cogstash.core.notes`
+  - keep wrapper-compatibility assertions only where compatibility is the point
+- Modify: `tests/cli/test_cli.py`
+  - migrate `Note` imports to `cogstash.core`
+- Modify: `tests/ui/test_browse_extended.py`
+  - migrate implementation tests to `cogstash.ui.app` and `cogstash.ui.browse`
+- Modify: `tests/ui/test_settings_extended.py`
+  - migrate implementation tests to `cogstash.ui.app` and `cogstash.ui.settings`
+- Reference: `docs/superpowers/specs/2026-04-22-wrapper-policy-and-direct-imports-design.md`
+  - approved scope for issues `#21` and `#22`
+
+## Baseline Verification
+
+Before implementation starts, run:
+
+```bash
+python -m pytest tests/core/test_search.py tests/ui/test_browse_extended.py tests/ui/test_settings_extended.py tests/cli/test_cli.py -q
+```
+
+Expected: PASS on the current branch before new tests or import-path edits.
+
+## Task 1: Lock the new import policy with failing tests
+
+**Files:**
+- Modify: `tests/core/test_search.py`
+- Modify: `tests/ui/test_browse_extended.py`
+- Modify: `tests/ui/test_settings_extended.py`
+- Modify: `tests/cli/test_cli.py`
+
+- [ ] **Step 1: Add a core-ownership regression test for note helpers**
+
+Add a focused test in `tests/core/test_search.py` that imports from `cogstash.core.notes` and asserts the core API remains directly usable for parse/search/edit flows.
+
+- [ ] **Step 2: Migrate one Browse test to owning-layer imports**
+
+Change one representative Browse test to import `CogStashConfig` from `cogstash.ui.app` or `cogstash.core` and `BrowseWindow` from `cogstash.ui.browse`.
+
+- [ ] **Step 3: Migrate one Settings test to owning-layer imports**
+
+Change one representative Settings test to import `CogStashConfig` from `cogstash.ui.app` or `cogstash.core` and `SettingsWindow` from `cogstash.ui.settings`.
+
+- [ ] **Step 4: Migrate one CLI test to `cogstash.core.Note`**
+
+Replace a representative `from cogstash.search import Note` import with `from cogstash.core import Note`.
+
+- [ ] **Step 5: Run focused tests to verify they fail only because production imports are not fully migrated yet**
+
+Run:
+
+```bash
+python -m pytest tests/core/test_search.py tests/ui/test_browse_extended.py tests/ui/test_settings_extended.py tests/cli/test_cli.py -q
+```
+
+Expected: at least one failure or import mismatch caused by the new owning-layer expectations.
+
+- [ ] **Step 6: Commit the red tests**
+
+```bash
+git add tests/core/test_search.py tests/ui/test_browse_extended.py tests/ui/test_settings_extended.py tests/cli/test_cli.py
+git commit -m "test: lock direct import ownership"
+```
+
+## Task 2: Move production imports to owning layers
+
+**Files:**
+- Modify: `src/cogstash/ui/browse.py`
+- Modify: `src/cogstash/ui/settings.py`
+
+- [ ] **Step 1: Update Browse imports**
+
+In `src/cogstash/ui/browse.py`, replace `cogstash.search` imports with direct owning-layer imports:
+
+- `DEFAULT_TAG_COLORS`, `Note`, `delete_note`, `edit_note`, `filter_by_tag`, `mark_done`, `parse_notes`, `search_notes` from `cogstash.core`
+- `_atomic_write` from `cogstash.core.notes`
+
+Keep `THEMES` and `platform_font` from `cogstash.ui.app` because they are UI-owned.
+
+- [ ] **Step 2: Update Settings imports**
+
+In `src/cogstash/ui/settings.py`, move clearly core-owned imports off `cogstash.ui.app`:
+
+- `DEFAULT_SMART_TAGS`, `CogStashConfig`, `merge_tags`, `save_config` from `cogstash.core`
+
+Keep `THEMES`, `WINDOW_SIZES`, `logger`, and `platform_font` from `cogstash.ui.app` because they remain UI-owned in this slice.
+
+- [ ] **Step 3: Run focused tests to verify green**
+
+Run:
+
+```bash
+python -m pytest tests/core/test_search.py tests/ui/test_browse_extended.py tests/ui/test_settings_extended.py tests/cli/test_cli.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the direct-import implementation**
+
+```bash
+git add src/cogstash/ui/browse.py src/cogstash/ui/settings.py tests/core/test_search.py tests/ui/test_browse_extended.py tests/ui/test_settings_extended.py tests/cli/test_cli.py
+git commit -m "refactor: use owning layer imports"
+```
+
+## Task 3: Make wrapper intent explicit without changing behavior
+
+**Files:**
+- Modify: `src/cogstash/app.py`
+- Modify: `src/cogstash/browse.py`
+- Modify: `src/cogstash/settings.py`
+- Modify: `src/cogstash/search.py`
+- Modify: `src/cogstash/_windows.py`
+- Verify: `tests/ui/test_app_compat.py`
+- Verify: `tests/core/test_search.py`
+
+- [ ] **Step 1: Add compatibility-shim docstrings**
+
+Add short module docstrings describing each root-level wrapper as a temporary compatibility shim and naming the real owning module.
+
+- [ ] **Step 2: Keep existing re-export behavior unchanged**
+
+Do not remove star imports, helper aliases, or `__all__` in this task. The purpose is policy clarity, not API removal.
+
+- [ ] **Step 3: Run wrapper-focused compatibility tests**
+
+Run:
+
+```bash
+python -m pytest tests/ui/test_app_compat.py tests/core/test_search.py -q
+```
+
+Expected: PASS, including wrapper re-export assertions.
+
+- [ ] **Step 4: Commit the wrapper-policy clarification**
+
+```bash
+git add src/cogstash/app.py src/cogstash/browse.py src/cogstash/settings.py src/cogstash/search.py src/cogstash/_windows.py
+git commit -m "docs: mark root wrappers as compatibility shims"
+```
+
+## Task 4: Full verification and issue update preparation
+
+**Files:**
+- Verify: touched source files and tests for this slice
+
+- [ ] **Step 1: Run the full targeted regression set**
+
+Run:
+
+```bash
+python -m pytest tests/core/test_search.py tests/ui/test_app_compat.py tests/ui/test_browse_extended.py tests/ui/test_settings_extended.py tests/cli/test_cli.py tests/cli/test_main.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run repo lint for touched files**
+
+Run:
+
+```bash
+python -m ruff check src/ tests/
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Review the diff for scope**
+
+Confirm the branch only covers:
+
+- wrapper intent documentation
+- direct import migration
+- test migration away from wrappers where compatibility is not the subject
+
+- [ ] **Step 4: Prepare issue and PR notes**
+
+Record that this slice covers:
+
+- issue `#21` wrapper role definition
+- issue `#22` direct owning-layer import migration
+- no changes yet for issues `#23`, `#24`, or `#25`

--- a/docs/superpowers/plans/2026-04-23-build-installer-artifact-contracts.md
+++ b/docs/superpowers/plans/2026-04-23-build-installer-artifact-contracts.md
@@ -1,0 +1,383 @@
+# Build And Installer Artifact Contracts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Centralize build, installer, and release artifact naming/path rules in one shared contract module and make the existing packaging scripts consume that contract instead of re-deriving conventions.
+
+**Architecture:** Add a small `scripts/_artifacts.py` helper that owns artifact identities, output paths, archive names, and installer staging names. Refactor `scripts/build.py`, `scripts/build_installer.py`, and the naming-sensitive parts of `.github/workflows/release.yml` to consume that shared contract while preserving current external artifact names.
+
+**Tech Stack:** Python, PyInstaller, Inno Setup, GitHub Actions YAML, `pytest`
+
+---
+
+## File Map
+
+- Create: `scripts/_artifacts.py`
+  Purpose: shared source of truth for artifact naming, expected output paths, archive names, and installer staging names.
+- Modify: `scripts/build.py`
+  Purpose: consume shared artifact naming helpers instead of local naming functions.
+- Modify: `scripts/build_installer.py`
+  Purpose: consume shared artifact naming/path helpers instead of duplicating naming/path rules.
+- Modify: `.github/workflows/release.yml`
+  Purpose: reduce inline rename/archive naming logic and rely on small Python helpers that apply the shared contract.
+- Modify: `tests/test_build_installer.py`
+  Purpose: add direct contract tests and update build/installer/release assertions to verify shared ownership.
+
+### Task 1: Add red tests for the shared artifact contract
+
+**Files:**
+- Modify: `tests/test_build_installer.py`
+
+- [ ] **Step 1: Add failing tests for artifact naming and lookup helpers**
+
+```python
+def _load_artifacts_module():
+    import importlib.util
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "scripts" / "_artifacts.py"
+    spec = importlib.util.spec_from_file_location("artifacts_contract", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_artifact_contract_build_names():
+    module = _load_artifacts_module()
+
+    assert module.get_executable_name(target="ui", bundle_mode="onefile", version="1.2.3") == "CogStash-1.2.3"
+    assert module.get_executable_name(target="ui", bundle_mode="onedir", version="1.2.3") == "CogStash-1.2.3-onedir"
+    assert module.get_executable_name(target="cli", bundle_mode="onefile", version="1.2.3") == "CogStash-CLI-1.2.3"
+
+
+def test_artifact_contract_windows_paths(tmp_path):
+    module = _load_artifacts_module()
+
+    layout = module.windows_artifact_layout(version="1.2.3", dist_dir=tmp_path / "dist")
+
+    assert layout.onedir_dir == tmp_path / "dist" / "CogStash-1.2.3-onedir"
+    assert layout.onedir_exe == layout.onedir_dir / "CogStash-1.2.3-onedir.exe"
+    assert layout.cli_exe == tmp_path / "dist" / "CogStash-CLI-1.2.3.exe"
+    assert layout.staged_app_dirname == "CogStash"
+    assert layout.staged_ui_exe_name == "CogStash.exe"
+    assert layout.staged_cli_exe_name == "CogStash-CLI.exe"
+
+
+def test_artifact_contract_release_archive_names():
+    module = _load_artifacts_module()
+
+    assert module.get_release_archive_name(tag="v1.2.3", platform_suffix="windows") == "CogStash-v1.2.3-windows.zip"
+    assert module.get_release_archive_name(tag="v1.2.3", platform_suffix="macos") == "CogStash-v1.2.3-macos.zip"
+    assert module.get_release_archive_name(tag="v1.2.3", platform_suffix="linux") == "CogStash-v1.2.3-linux.tar.gz"
+```
+
+- [ ] **Step 2: Run the new contract tests to verify they fail**
+
+Run: `python -m pytest tests/test_build_installer.py -k "artifact_contract" -q`
+Expected: FAIL with `FileNotFoundError`, `ModuleNotFoundError`, or missing helper attributes because `scripts/_artifacts.py` does not exist yet.
+
+- [ ] **Step 3: Add a failing test that build/installer code imports the shared contract**
+
+```python
+def test_build_and_installer_import_shared_artifact_contract():
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[1]
+    build_source = (repo_root / "scripts" / "build.py").read_text(encoding="utf-8")
+    installer_source = (repo_root / "scripts" / "build_installer.py").read_text(encoding="utf-8")
+
+    assert "from _artifacts import " in build_source or "import _artifacts" in build_source
+    assert "from _artifacts import " in installer_source or "import _artifacts" in installer_source
+```
+
+- [ ] **Step 4: Run the import-ownership test to verify it fails**
+
+Run: `python -m pytest tests/test_build_installer.py -k "shared_artifact_contract" -q`
+Expected: FAIL because the scripts still own duplicated local naming helpers.
+
+- [ ] **Step 5: Commit the red test checkpoint**
+
+```bash
+git add tests/test_build_installer.py
+git commit -m "test: define artifact contract coverage"
+```
+
+### Task 2: Implement the shared artifact-contract module
+
+**Files:**
+- Create: `scripts/_artifacts.py`
+- Modify: `tests/test_build_installer.py`
+
+- [ ] **Step 1: Create the contract module with explicit artifact helpers**
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+STAGED_APP_DIRNAME = "CogStash"
+STAGED_UI_EXE_NAME = "CogStash.exe"
+STAGED_CLI_EXE_NAME = "CogStash-CLI.exe"
+
+
+def get_executable_name(*, target: str, bundle_mode: str, version: str) -> str:
+    if target == "ui":
+        return f"CogStash-{version}" if bundle_mode == "onefile" else f"CogStash-{version}-onedir"
+    if target == "cli":
+        return f"CogStash-CLI-{version}"
+    raise ValueError(f"Unknown target: {target}")
+
+
+def get_onedir_dir_name(version: str) -> str:
+    return get_executable_name(target="ui", bundle_mode="onedir", version=version)
+
+
+def get_onedir_exe_name(version: str) -> str:
+    return f"{get_onedir_dir_name(version)}.exe"
+
+
+def get_cli_exe_name(version: str) -> str:
+    return f"{get_executable_name(target='cli', bundle_mode='onefile', version=version)}.exe"
+
+
+def get_release_archive_name(*, tag: str, platform_suffix: str) -> str:
+    if platform_suffix == "windows":
+        return f"CogStash-{tag}-windows.zip"
+    if platform_suffix == "macos":
+        return f"CogStash-{tag}-macos.zip"
+    if platform_suffix == "linux":
+        return f"CogStash-{tag}-linux.tar.gz"
+    raise ValueError(f"Unknown platform suffix: {platform_suffix}")
+
+
+@dataclass(frozen=True)
+class WindowsArtifactLayout:
+    onedir_dir: Path
+    onedir_exe: Path
+    cli_exe: Path
+    staged_app_dirname: str = STAGED_APP_DIRNAME
+    staged_ui_exe_name: str = STAGED_UI_EXE_NAME
+    staged_cli_exe_name: str = STAGED_CLI_EXE_NAME
+
+
+def windows_artifact_layout(*, version: str, dist_dir: Path) -> WindowsArtifactLayout:
+    onedir_dir = dist_dir / get_onedir_dir_name(version)
+    return WindowsArtifactLayout(
+        onedir_dir=onedir_dir,
+        onedir_exe=onedir_dir / get_onedir_exe_name(version),
+        cli_exe=dist_dir / get_cli_exe_name(version),
+    )
+```
+
+- [ ] **Step 2: Run the new contract tests and make them pass**
+
+Run: `python -m pytest tests/test_build_installer.py -k "artifact_contract" -q`
+Expected: PASS
+
+- [ ] **Step 3: Commit the new shared contract module**
+
+```bash
+git add scripts/_artifacts.py tests/test_build_installer.py
+git commit -m "feat: add shared artifact contract"
+```
+
+### Task 3: Refactor build and installer scripts to consume the contract
+
+**Files:**
+- Modify: `scripts/build.py`
+- Modify: `scripts/build_installer.py`
+- Modify: `tests/test_build_installer.py`
+
+- [ ] **Step 1: Replace duplicated naming helpers in `scripts/build.py`**
+
+```python
+from _artifacts import get_executable_name
+
+
+def run_pyinstaller(
+    *,
+    target: str,
+    bundle_mode: str,
+    debug: bool,
+    icon_path: str | None,
+    version: str,
+) -> None:
+    entry = get_entrypoint(target)
+    hidden_imports = get_hidden_imports(target)
+    name = get_executable_name(target=target, bundle_mode=bundle_mode, version=version)
+    ...
+```
+
+- [ ] **Step 2: Replace duplicated naming/path helpers in `scripts/build_installer.py`**
+
+```python
+from _artifacts import (
+    STAGED_APP_DIRNAME,
+    STAGED_CLI_EXE_NAME,
+    STAGED_UI_EXE_NAME,
+    windows_artifact_layout,
+)
+
+
+def find_windows_onedir_bundle(dist_dir: Path, version: str) -> Path:
+    layout = windows_artifact_layout(version=version, dist_dir=dist_dir)
+    if not layout.onedir_dir.is_dir():
+        raise FileNotFoundError(f"Windows onedir bundle not found: {layout.onedir_dir}")
+    if not layout.onedir_exe.is_file():
+        raise FileNotFoundError(f"Expected bundle executable not found: {layout.onedir_exe}")
+    return layout.onedir_dir
+
+
+def find_windows_cli_binary(dist_dir: Path, version: str) -> Path:
+    layout = windows_artifact_layout(version=version, dist_dir=dist_dir)
+    if not layout.cli_exe.is_file():
+        raise FileNotFoundError(f"Windows CLI binary not found: {layout.cli_exe}")
+    return layout.cli_exe
+```
+
+- [ ] **Step 3: Update tests to assert shared-contract consumption**
+
+```python
+def test_build_and_installer_import_shared_artifact_contract():
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[1]
+    build_source = (repo_root / "scripts" / "build.py").read_text(encoding="utf-8")
+    installer_source = (repo_root / "scripts" / "build_installer.py").read_text(encoding="utf-8")
+
+    assert "from _artifacts import " in build_source
+    assert "from _artifacts import " in installer_source
+    assert "def get_onedir_dir_name" not in installer_source
+```
+
+- [ ] **Step 4: Run the script-level build/installer tests**
+
+Run: `python -m pytest tests/test_build_installer.py -k "build or installer or artifact_contract or shared_artifact_contract" -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit the script refactor**
+
+```bash
+git add scripts/build.py scripts/build_installer.py tests/test_build_installer.py
+git commit -m "refactor: share artifact naming contracts"
+```
+
+### Task 4: Reduce workflow naming duplication
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+- Modify: `tests/test_build_installer.py`
+
+- [ ] **Step 1: Add a small Python helper step in the workflow for naming-sensitive rename/archive outputs**
+
+```yaml
+      - name: Rename onefile artifacts
+        run: |
+          from pathlib import Path
+          import os
+
+          from _artifacts import get_executable_name
+
+          suffix = "${{ matrix.artifact_suffix }}"
+          ext = "${{ matrix.exe_ext }}"
+          version = os.environ["GITHUB_REF_NAME"]
+          dist_dir = Path("dist")
+
+          ui_source = dist_dir / f"{get_executable_name(target='ui', bundle_mode='onefile', version=version)}{ext}"
+          cli_source = dist_dir / f"{get_executable_name(target='cli', bundle_mode='onefile', version=version)}{ext}"
+          ui_target = dist_dir / f"CogStash-{version}-{suffix}{ext}"
+          cli_target = dist_dir / f"CogStash-CLI-{version}-{suffix}{ext}"
+          ui_source.replace(ui_target)
+          cli_source.replace(cli_target)
+        shell: python
+```
+
+- [ ] **Step 2: Keep workflow orchestration intact but remove duplicated artifact identity assumptions where practical**
+
+```yaml
+      - name: Archive onedir bundle (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          import os
+          import subprocess
+          from _artifacts import get_release_archive_name
+
+          archive_name = get_release_archive_name(tag=os.environ["GITHUB_REF_NAME"], platform_suffix="windows")
+          subprocess.run(["powershell", "-Command", f"Compress-Archive -Path dist/CogStash-*-onedir -DestinationPath dist/{archive_name}"], check=True)
+        shell: python
+```
+
+- [ ] **Step 3: Update workflow assertions in tests**
+
+```python
+def test_release_workflow_uses_shared_artifact_contract():
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[1]
+    content = (repo_root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert "from _artifacts import get_executable_name" in content
+    assert "from _artifacts import get_release_archive_name" in content
+    assert "dist/CogStash-v*-setup.exe" in content
+```
+
+- [ ] **Step 4: Run the workflow-related tests**
+
+Run: `python -m pytest tests/test_build_installer.py -k "release_workflow" -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit the workflow contract cleanup**
+
+```bash
+git add .github/workflows/release.yml tests/test_build_installer.py
+git commit -m "refactor: centralize release artifact naming"
+```
+
+### Task 5: Final verification and finish
+
+**Files:**
+- Verify: `scripts/_artifacts.py`
+- Verify: `scripts/build.py`
+- Verify: `scripts/build_installer.py`
+- Verify: `.github/workflows/release.yml`
+- Verify: `tests/test_build_installer.py`
+
+- [ ] **Step 1: Run lint on the changed scripts and tests**
+
+Run: `python -m ruff check scripts/_artifacts.py scripts/build.py scripts/build_installer.py tests/test_build_installer.py`
+Expected: PASS
+
+- [ ] **Step 2: Run the full focused packaging test suite**
+
+Run: `python -m pytest tests/test_build_installer.py -q`
+Expected: PASS
+
+- [ ] **Step 3: Run targeted typing if the changed scripts are included in static checking**
+
+Run: `python -m mypy scripts/_artifacts.py scripts/build.py scripts/build_installer.py`
+Expected: PASS or, if scripts are intentionally outside mypy scope, document that clearly instead of guessing.
+
+- [ ] **Step 4: Inspect the final diff**
+
+Run: `git diff -- scripts/_artifacts.py scripts/build.py scripts/build_installer.py .github/workflows/release.yml tests/test_build_installer.py`
+Expected: only shared artifact contract and related test/workflow changes.
+
+- [ ] **Step 5: Commit any final verification fixes if needed**
+
+```bash
+git add scripts/_artifacts.py scripts/build.py scripts/build_installer.py .github/workflows/release.yml tests/test_build_installer.py
+git commit -m "test: finalize artifact contract coverage"
+```
+
+- [ ] **Step 6: Prepare handoff notes**
+
+```text
+Summarize:
+- shared artifact contract module added
+- build and installer scripts now consume one source of truth
+- release workflow uses less inline naming logic
+- verification commands and results
+```

--- a/docs/superpowers/specs/2026-04-22-ui-queue-thread-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-04-22-ui-queue-thread-lifecycle-design.md
@@ -1,0 +1,175 @@
+# UI Queue And Thread Lifecycle Design
+
+## Context
+
+Issue `#24` is the next architecture-boundary slice under umbrella issue `#12`.
+
+Today, `src/cogstash/ui/app.py` owns all of the following at once:
+
+- Tk window behavior
+- raw queue message names
+- tray callback wiring
+- global hotkey registration
+- main-thread queue polling
+- shutdown cleanup for listener state
+
+That works, but the contracts are mostly implicit. Tray and hotkey behavior communicate with the app through ad hoc string messages, and startup/shutdown responsibilities are spread across `create_tray_icon()`, `CogStash.poll_queue()`, and `main()`. This makes the runtime behavior harder to change safely because the message flow is not represented as an explicit boundary.
+
+## Goals
+
+- define an explicit UI runtime contract for queue commands
+- give one module ownership of tray, hotkey, and queue-lifecycle wiring
+- preserve current user-visible behavior
+- improve testability of startup and shutdown behavior
+- reduce coupling inside `ui/app.py`
+
+## Non-Goals
+
+- redesign the Tk UI structure
+- change the tray menu contents
+- change the hotkey feature or recovery behavior
+- introduce async or multiprocessing primitives
+- move browse/settings window behavior out of `CogStash`
+
+## Recommended Approach
+
+Extract a dedicated runtime boundary module, tentatively `src/cogstash/ui/app_runtime.py`, that owns the lifecycle contract between background integrations and the Tk main thread.
+
+This module will:
+
+- define the supported queue command types in one place
+- provide helpers that enqueue those commands from tray and hotkey callbacks
+- provide a dispatcher/drain helper for the Tk thread to consume commands through explicit callbacks
+- provide startup helpers that initialize tray and hotkey integrations
+- return runtime handles that can be shut down consistently during application exit
+
+`src/cogstash/ui/app.py` will remain the home of the `CogStash` UI object and its direct Tk behavior, but it will stop being the source of truth for runtime message semantics.
+
+## Ownership Boundaries
+
+### `ui/app.py`
+
+Owns:
+
+- Tk root creation and top-level app startup sequence
+- the `CogStash` UI object
+- concrete UI actions such as `show_window()`, `_open_browse()`, `_open_settings()`, and note submission
+- config-driven window updates and widget behavior
+
+Does not own:
+
+- queue command definitions
+- tray callback message semantics
+- hotkey listener construction details
+- queue-drain branching over command values
+- shutdown sequencing for runtime integrations beyond invoking runtime helpers
+
+### `ui/app_runtime.py`
+
+Owns:
+
+- queue command definitions and naming
+- queue enqueue helpers for tray and hotkey integrations
+- queue-drain and dispatch behavior
+- startup helpers for tray and hotkey runtime pieces
+- shutdown handles or cleanup helpers for started integrations
+
+Does not own:
+
+- widget creation
+- Tk layout and styling
+- settings or browse window implementation
+- note-writing behavior
+
+## Contract Shape
+
+The runtime boundary should make the supported message flow explicit. The exact representation can be an enum, named constants, or another typed structure, but the contract must be centralized and testable.
+
+Supported commands remain:
+
+- show the capture window
+- open browse
+- open settings
+- quit the app
+
+The queue consumer must dispatch through explicit callbacks supplied by `app.py`. `app.py` should no longer hardcode raw message strings inside `CogStash.poll_queue()`.
+
+Unknown commands should not crash the poll loop. The runtime boundary should ignore or log them in a controlled way so that queue draining remains robust.
+
+## Startup And Shutdown Design
+
+Startup in `main()` should be split into two layers:
+
+- `app.py` constructs config, root, dialogs, and the `CogStash` instance
+- `app_runtime.py` starts integrations that communicate back into the app through the queue contract
+
+The extracted runtime startup should:
+
+- initialize tray behavior against the shared queue
+- initialize the global hotkey listener against the shared queue
+- surface the hotkey failure condition back to `main()` so existing warning UX remains intact
+- return any handles needed for shutdown
+
+Shutdown should be explicit and centralized:
+
+- main loop exit leads to one cleanup path
+- started listeners or tray resources are stopped through runtime-owned handles
+- cleanup remains safe when startup partially fails, especially when hotkey registration fails
+
+## Error Handling
+
+Behavior should remain unchanged from the user perspective:
+
+- tray support still degrades gracefully if dependencies are unavailable
+- hotkey registration failures still produce the existing warning flow and logging
+- duplicate-instance protection remains outside this slice
+
+Additional runtime-specific expectations:
+
+- queue dispatch should not break permanently because of one unexpected command
+- partially initialized runtime state must still be safe to shut down
+
+## Testing Strategy
+
+Add focused tests for the runtime boundary rather than relying only on end-to-end startup tests.
+
+Required coverage:
+
+- queue dispatch routes each supported command to the expected callback
+- queue draining tolerates an empty queue
+- unknown commands are handled safely
+- tray and hotkey enqueue behavior uses the centralized contract
+- startup helpers return handles that can be shut down safely
+- `main()` or `CogStash` tests verify delegation into the runtime boundary rather than open-coded lifecycle logic
+
+Existing behavior tests around hotkey failure, startup continuation, and settings opening should continue to pass with minimal semantic changes.
+
+## Migration Plan
+
+Implement this in one slice:
+
+1. create the runtime module and move command definitions plus queue dispatch there
+2. move tray and hotkey enqueue wiring into runtime helpers
+3. update `app.py` to delegate queue polling and runtime startup/shutdown
+4. add or update focused tests
+
+This keeps the change narrow while still establishing a real ownership boundary.
+
+## Risks And Mitigations
+
+Risk: startup behavior regresses because tray or hotkey initialization changes shape.
+Mitigation: keep current user-facing behavior identical and preserve existing startup tests.
+
+Risk: queue dispatch moves but Tk-thread assumptions become less obvious.
+Mitigation: require callback-based dispatch that is always invoked from the Tk poll loop.
+
+Risk: over-extraction produces too many tiny modules.
+Mitigation: keep this slice to a single runtime boundary module.
+
+## Acceptance Criteria
+
+- `ui/app.py` no longer defines raw queue command handling inline as the source of truth
+- tray and hotkey integrations enqueue through a shared explicit contract
+- runtime startup and shutdown behavior are delegated through a dedicated module
+- tests cover the extracted contract directly
+- no user-visible behavior change is introduced for capture, browse, settings, tray, or quit flows

--- a/docs/superpowers/specs/2026-04-22-windows-responsibility-boundaries-design.md
+++ b/docs/superpowers/specs/2026-04-22-windows-responsibility-boundaries-design.md
@@ -1,0 +1,493 @@
+# Windows Responsibility Boundaries Design
+
+## Parent Issues
+
+- Umbrella: `#12` — Tighten post-split architecture boundaries
+- Current slice:
+  - `#23` — Consolidate and document Windows-specific responsibilities
+
+## Summary
+
+Windows behavior now works across CLI, UI, and installer flows, but the
+responsibility model is still easy to misread from the codebase. The current
+split is partly explicit:
+
+- CLI console attachment lives in `cogstash.cli.windows`
+- GUI single-instance behavior lives in `cogstash.ui.windows`
+- installed-run and startup-script detection lives in `cogstash.ui.install_state`
+
+But some UI-only Windows runtime behavior still sits inside `cogstash.ui.app`
+and `cogstash.ui.settings`, while installer behavior is encoded separately in
+`installer/windows/CogStash.iss`. That leaves future contributors without one
+clear answer to a basic question: when a Windows-specific change is needed,
+which layer owns it?
+
+This slice should define and enforce that ownership model with a small,
+practical consolidation. The goal is not to redesign Windows behavior. The goal
+is to make the existing behavior land in the right modules and to document the
+rules clearly enough that later changes do not drift back into `app.py`,
+settings code, or installer script comments by accident.
+
+## Problem
+
+Windows-specific behavior is currently spread across these places:
+
+- `src/cogstash/cli/windows.py`
+- `src/cogstash/ui/windows.py`
+- `src/cogstash/ui/install_state.py`
+- `src/cogstash/ui/app.py`
+- `src/cogstash/ui/settings.py`
+- `installer/windows/CogStash.iss`
+- compatibility wrapper `src/cogstash/_windows.py`
+
+The split is not arbitrary, but it is not fully documented or reflected in the
+module structure either.
+
+Current examples of drift:
+
+- `ui.app` owns GUI startup and tray logic, but also still contains a Windows
+  DPI helper and Windows-specific file-opening behavior inside the tray flow
+- `ui.settings` owns settings UI, but also directly implements startup-script
+  creation/removal behavior while separately consulting `ui.install_state` for
+  installer-managed state
+- the installer script writes `.cogstash-installed` and startup scripts, but
+  the runtime-side contract for consuming those artifacts is only implicit in
+  tests and scattered helper usage
+- `_windows.py` still presents a compatibility surface that combines CLI and UI
+  Windows helpers, even though the real owners now live in separate layers
+
+This is not a correctness bug today. It is a maintenance hazard:
+
+- contributors may add new Windows logic to `app.py` because it already has
+  some, even when a dedicated owner exists
+- installer/runtime contracts can drift because the code and script are not
+  described together anywhere
+- future cleanup becomes riskier because there is no explicit rule for what
+  belongs in `cli.windows` vs `ui.windows` vs `ui.install_state`
+
+## Goals
+
+- Define the ownership model for Windows-specific code across CLI, UI runtime,
+  installer-aware runtime state, and installer script behavior
+- Reduce scattered Windows-specific runtime helpers where a small consolidation
+  makes the ownership clearer
+- Keep the runtime/install-state contract visible in code and documentation
+- Preserve current behavior while improving module boundaries
+- Keep the slice small enough that it does not absorb queue/thread lifecycle
+  work from `#24` or build/artifact contract work from `#25`
+
+## Non-Goals
+
+- Rewriting installer behavior
+- Changing the current startup-at-login user experience
+- Changing the duplicate-instance policy
+- Redesigning CLI console attachment behavior
+- Removing the root `_windows.py` compatibility shim in this slice
+- Bundling build/release contract changes into the Windows ownership cleanup
+
+## Current Ownership Inventory
+
+### 1. `src/cogstash/cli/windows.py`
+
+Current role:
+
+- attach packaged CLI processes to the parent Windows console when stdio is
+  missing
+
+Assessment:
+
+- correct owner for CLI-only Windows console preparation
+- should remain narrow and CLI-only
+- should not grow UI or installer detection responsibilities
+
+### 2. `src/cogstash/ui/windows.py`
+
+Current role:
+
+- GUI single-instance mutex acquisition and release
+
+Assessment:
+
+- correct owner for GUI-runtime-only Windows process coordination
+- should remain focused on UI runtime process primitives
+- should not absorb installer-detection or startup-script concerns
+
+### 3. `src/cogstash/ui/install_state.py`
+
+Current role:
+
+- determine whether the app is running as an installed Windows build
+- expose installer marker and startup-script presence state to runtime code
+
+Assessment:
+
+- correct owner for runtime visibility into installer-managed state
+- should remain the bridge between installer artifacts and UI runtime decisions
+- should not own GUI actions like creating/removing startup scripts directly
+
+### 4. `src/cogstash/ui/app.py`
+
+Current Windows-specific behavior:
+
+- `configure_dpi()`
+- Windows branch in tray file opening (`os.startfile`)
+- consumption of `ui.windows` and `ui.install_state` during startup
+
+Assessment:
+
+- startup orchestration belongs here
+- standalone Windows runtime helpers such as DPI setup and Windows shell file
+  opening should not stay embedded here long-term
+- startup should depend on well-named Windows helpers rather than defining them
+  inline
+
+### 5. `src/cogstash/ui/settings.py`
+
+Current Windows-specific behavior:
+
+- startup batch-script creation/removal
+- startup-state reflection based on `startup_script_exists()`
+- Windows shell opening branch in About/help actions
+- installer-aware wizard completion branch
+
+Assessment:
+
+- settings UX belongs here
+- raw Windows startup-script and Windows shell helper behavior should be pushed
+  behind a dedicated UI-runtime Windows helper module where practical
+- consuming installer state from `ui.install_state` is correct, but the
+  imperative Windows file/script operations should not stay scattered across
+  settings code
+
+### 6. `installer/windows/CogStash.iss`
+
+Current role:
+
+- write installed marker file
+- optionally create startup batch script
+- optionally add CLI directory to PATH
+- clean up installer-owned artifacts on uninstall
+
+Assessment:
+
+- correct owner for installation-time side effects
+- should remain the only owner of installer-time writes to install directory,
+  PATH ownership records, and uninstall cleanup
+- runtime code should consume installer artifacts; it should not reproduce
+  installer policy decisions
+
+## Chosen Approach
+
+The preferred direction is to define **four explicit Windows ownership zones**
+and make one small structural change so the code matches that model.
+
+### A. CLI Windows ownership
+
+Owner:
+
+- `cogstash.cli.windows`
+
+Responsibilities:
+
+- CLI console attachment
+- CLI stdio restoration for packaged Windows command execution
+
+Rule:
+
+- if the behavior only matters when a terminal-facing CLI process starts, it
+  belongs here
+
+### B. UI Windows runtime ownership
+
+Owner:
+
+- `cogstash.ui.windows`
+- plus a new dedicated helper module such as `cogstash.ui.windows_runtime`
+
+Responsibilities:
+
+- GUI single-instance primitives
+- DPI-awareness setup
+- Windows shell/open-file helper behavior used by UI runtime flows
+- startup-script create/remove helpers used by the settings UI
+
+Rule:
+
+- if the behavior is an imperative Windows runtime action performed by the GUI
+  app, it belongs in the UI Windows runtime layer, not inline in `app.py` or
+  `settings.py`
+
+### C. Installer-state ownership
+
+Owner:
+
+- `cogstash.ui.install_state`
+
+Responsibilities:
+
+- detect installed Windows runtime state
+- expose install marker presence
+- expose startup-script presence
+- answer runtime questions such as “should installer welcome show?”
+
+Rule:
+
+- if the runtime is reading installer-managed state rather than performing a UI
+  runtime action, it belongs here
+
+### D. Installer ownership
+
+Owner:
+
+- `installer/windows/CogStash.iss`
+
+Responsibilities:
+
+- create/remove install-time artifacts
+- manage installer-owned PATH updates
+- write install marker
+- write uninstall cleanup behavior
+
+Rule:
+
+- if the operation happens because the installer is running, it belongs here,
+  not in Python runtime code
+
+## Recommended Structural Change
+
+To make the ownership model visible in code, this slice should introduce a
+small UI-runtime Windows helper module, for example:
+
+- `src/cogstash/ui/windows_runtime.py`
+
+Expected responsibilities for that module:
+
+- `configure_dpi()` or renamed equivalent
+- Windows shell open helpers used by tray/about/settings flows
+- startup script write/remove helpers currently implemented directly in
+  `ui.settings`
+
+This is intentionally narrower than a full `ui.windows` expansion.
+
+Why not put everything into `ui.windows`?
+
+- `ui.windows` already has a clear low-level runtime-process role centered on
+  the single-instance mutex
+- mixing mutex/process primitives with shell-opening and startup-script helpers
+  would create another catch-all module
+
+A dedicated `windows_runtime` module keeps the split readable:
+
+- `ui.windows` → process/runtime primitives
+- `ui.windows_runtime` → higher-level Windows GUI runtime actions
+- `ui.install_state` → installer-derived runtime state
+
+## Module-Level Rules After This Slice
+
+### `cogstash.cli.windows`
+
+Must own:
+
+- CLI console attach/open-stream behavior
+
+Must not own:
+
+- installer marker detection
+- GUI mutex logic
+- settings/startup-script operations
+
+### `cogstash.ui.windows`
+
+Must own:
+
+- GUI single-instance primitives
+
+Must not own:
+
+- startup batch-script creation/removal
+- installer marker detection
+- PATH/installer script logic
+
+### `cogstash.ui.windows_runtime`
+
+Must own:
+
+- GUI-runtime Windows actions such as DPI setup
+- shell-opening helpers for UI interactions
+- startup-script write/remove helpers invoked by settings UI
+
+Must not own:
+
+- installer marker detection logic
+- installer PATH ownership logic
+- CLI console behavior
+
+### `cogstash.ui.install_state`
+
+Must own:
+
+- reading installed-run state from runtime environment and installer artifacts
+- startup-script presence checks
+- installer-welcome decision logic
+
+Must not own:
+
+- creating/removing startup scripts
+- GUI actions or dialogs
+- CLI console or mutex behavior
+
+### `installer/windows/CogStash.iss`
+
+Must own:
+
+- creation/removal of installer-managed artifacts
+- PATH modifications and uninstall cleanup
+
+Must not rely on:
+
+- undocumented Python-side magic comments or hidden assumptions
+
+The Python runtime should be able to point to explicit artifact readers in
+`ui.install_state` for every installer-managed runtime contract it consumes.
+
+## Compatibility Wrapper Policy
+
+`src/cogstash/_windows.py` should remain a compatibility shim in this slice,
+but its role should stay narrow:
+
+- re-export CLI/UI Windows owners for compatibility only
+- not serve as the preferred internal import path
+
+Internal code should continue importing:
+
+- `cogstash.cli.windows` for CLI console preparation
+- `cogstash.ui.windows` for GUI mutex behavior
+- `cogstash.ui.windows_runtime` for GUI Windows runtime actions
+- `cogstash.ui.install_state` for installer-derived runtime state
+
+## Alternatives Considered
+
+### 1. Documentation only, no code movement
+
+Pros:
+
+- lowest implementation risk
+- almost no regression surface
+
+Cons:
+
+- leaves Windows runtime helpers embedded in `app.py` and `settings.py`
+- makes the documented ownership model less enforceable
+
+Rejected because this issue explicitly asks to consolidate where practical.
+
+### 2. Collapse all Windows logic into one module
+
+Pros:
+
+- one obvious place to look
+
+Cons:
+
+- mixes CLI, UI runtime, installer-state, and process primitives together
+- recreates a monolith similar to the old `_windows.py` ambiguity
+
+Rejected.
+
+### 3. Recommended: four ownership zones with one new UI runtime helper module
+
+Pros:
+
+- aligns code structure with actual concerns
+- small enough to land safely
+- documents installer/runtime boundaries clearly
+
+Cons:
+
+- introduces one additional module
+- leaves some Windows references in app/settings call sites, though they become
+  delegated rather than owned there
+
+Chosen.
+
+## Risks
+
+### 1. Moving too much behavior at once
+
+If this slice tries to also redesign onboarding, queue lifecycle, or build
+contracts, the boundary cleanup will lose focus.
+
+Mitigation:
+
+- keep scope to ownership, documentation, and small helper extraction only
+
+### 2. Blurring installer-state vs runtime-action APIs
+
+If `ui.install_state` starts creating or mutating startup scripts, it will blur
+the exact contract this issue is trying to clarify.
+
+Mitigation:
+
+- keep read/decision logic in `install_state`
+- keep imperative GUI Windows actions in `windows_runtime`
+
+### 3. Hidden test assumptions
+
+Some tests currently assert behavior by monkeypatching symbols in `ui.app` or
+`ui.settings`.
+
+Mitigation:
+
+- update tests to patch the new owning helpers where needed
+- add lightweight ownership tests that lock the intended module split
+
+## Testing Strategy
+
+This slice should verify:
+
+1. CLI Windows startup still uses `cogstash.cli.windows`
+2. GUI single-instance behavior still uses `cogstash.ui.windows`
+3. installer-state decisions still flow through `cogstash.ui.install_state`
+4. startup-script behavior and Windows shell-opening helpers are delegated
+   through the new UI runtime Windows owner
+5. compatibility wrapper behavior in `_windows.py` still works where preserved
+
+Expected verification:
+
+- targeted `tests/ui/test_app.py`
+- targeted `tests/ui/test_settings.py`
+- targeted `tests/ui/test_app_compat.py`
+- targeted `tests/cli/test_cli.py` and/or `tests/cli/test_main.py`
+- installer contract tests in `tests/test_build_installer.py`
+- repository lint/test checks for touched files
+
+## Success Criteria
+
+This slice is successful when:
+
+- Windows-specific responsibilities are documented in one spec with clear
+  ownership rules
+- UI-only Windows runtime helpers no longer live primarily inside `ui.app` or
+  `ui.settings`
+- installer-state reads remain centralized in `ui.install_state`
+- installer-time artifact creation/removal remains clearly owned by the Inno
+  Setup script
+- `_windows.py` remains only a compatibility surface, not the preferred
+  internal API
+- targeted tests and lint stay green
+
+## Likely Files
+
+- `src/cogstash/cli/windows.py`
+- `src/cogstash/ui/windows.py`
+- `src/cogstash/ui/install_state.py`
+- `src/cogstash/ui/app.py`
+- `src/cogstash/ui/settings.py`
+- `src/cogstash/ui/windows_runtime.py` (new)
+- `src/cogstash/_windows.py`
+- `installer/windows/CogStash.iss`
+- `tests/ui/test_app.py`
+- `tests/ui/test_settings.py`
+- `tests/ui/test_app_compat.py`
+- `tests/cli/test_main.py`
+- `tests/test_build_installer.py`

--- a/docs/superpowers/specs/2026-04-22-wrapper-policy-and-direct-imports-design.md
+++ b/docs/superpowers/specs/2026-04-22-wrapper-policy-and-direct-imports-design.md
@@ -1,0 +1,342 @@
+# Wrapper Policy and Direct Imports Design
+
+## Parent Issues
+
+- Umbrella: `#12` — Tighten post-split architecture boundaries
+- First slice:
+  - `#21` — Define the long-term role of root-level compatibility wrappers
+  - `#22` — Replace facade imports with direct owning-layer imports
+
+## Summary
+
+This slice tightens the first post-split architecture boundary by doing two things together:
+
+1. define a temporary but explicit compatibility role for the root-level wrapper modules
+2. migrate internal modules and tests toward the true owning layers instead of wrapper/facade imports
+
+The goal is not to remove every wrapper immediately. The goal is to stop new hidden coupling, make ownership visible in the code, and reduce the maintenance cost of the current compatibility surface without creating an avoidable public-API break.
+
+## Problem
+
+The CLI/UI/core split shipped, but several root-level modules still behave as broad re-export layers:
+
+- `src/cogstash/app.py`
+- `src/cogstash/browse.py`
+- `src/cogstash/settings.py`
+- `src/cogstash/search.py`
+- `src/cogstash/_windows.py`
+
+At the same time, some internal code still imports through facades rather than directly from their owning layer:
+
+- `src/cogstash/ui/browse.py`
+- `src/cogstash/ui/settings.py`
+
+The result is architectural drift:
+
+- true ownership is harder to see
+- internal dependency direction is less obvious than it should be
+- tests and internal callers keep wrapper modules alive by habit rather than intent
+- future cleanup becomes riskier because there is no explicit wrapper policy
+
+## Goals
+
+- Define which root-level wrappers are compatibility shims for now
+- Reduce internal imports that rely on wrappers or unrelated façade modules
+- Start migrating tests toward owning modules where they are testing internals rather than compatibility
+- Preserve a deliberate migration path for external/public imports
+- Keep the slice small enough that it can land without mixing in Windows/lifecycle/build refactors from later child issues
+
+## Non-Goals
+
+- Removing every root-level wrapper in this slice
+- Breaking public entrypoints without a migration plan
+- Reworking Windows ownership (`#23`)
+- Reworking UI queue/thread lifecycle (`#24`)
+- Reworking build/installer contracts (`#25`)
+- Broad unrelated file reorganization
+
+## Current Wrapper Inventory
+
+### 1. `src/cogstash/app.py`
+
+Current behavior:
+
+- broad `from cogstash.ui.app import *`
+- used by compatibility-oriented tests and by `src/cogstash/__main__.py`
+
+Assessment:
+
+- should remain temporarily as a compatibility shim
+- should not be used by new internal modules as the preferred import source
+
+### 2. `src/cogstash/browse.py`
+
+Current behavior:
+
+- broad `from cogstash.ui.browse import *`
+- used mostly by older/compatibility-style UI tests
+
+Assessment:
+
+- should remain temporarily as a compatibility shim
+- internal imports should prefer `cogstash.ui.browse`
+
+### 3. `src/cogstash/settings.py`
+
+Current behavior:
+
+- broad `from cogstash.ui.settings import *`
+- used mostly by older/compatibility-style UI tests
+
+Assessment:
+
+- should remain temporarily as a compatibility shim
+- internal imports should prefer `cogstash.ui.settings`
+
+### 4. `src/cogstash/search.py`
+
+Current behavior:
+
+- compatibility wrapper around `cogstash.core.notes`
+- also re-exports internal helpers such as `_atomic_write` and `_note_line_span`
+
+Assessment:
+
+- this is the most architecturally misleading wrapper because it hides the real owner (`core.notes`)
+- internal imports should stop using it where possible in this slice
+- compatibility behavior can remain temporarily for callers/tests that still need it
+
+### 5. `src/cogstash/_windows.py`
+
+Current behavior:
+
+- thin aggregator of CLI- and UI-owned Windows helpers
+
+Assessment:
+
+- keep as a compatibility surface for now
+- do not expand its role in this slice
+- defer deeper ownership changes to `#23`
+
+## Chosen Approach
+
+The preferred direction is a **two-speed migration**:
+
+### A. Compatibility wrappers stay, but become explicitly compatibility-only
+
+Root wrapper modules remain in place during this slice so external compatibility is preserved.
+
+However, they should be treated as:
+
+- transitional public/import compatibility surfaces
+- not the preferred internal import path
+- intentionally narrow in purpose
+
+Where helpful, wrapper modules should be documented in code as compatibility shims so future contributors do not mistake them for the owning implementation modules.
+
+### B. Internal modules and tests migrate to owning layers now
+
+The actual architecture cleanup happens by changing internal callers and non-compatibility tests to import from the real owner:
+
+- `core` for shared note/config/domain logic
+- `ui` for UI implementation modules
+- `cli` for CLI-specific behavior
+
+This preserves a migration path while still making the internal architecture clearer immediately.
+
+## Import Policy After This Slice
+
+### Internal module rules
+
+Within `src/cogstash/`, the preferred imports should be:
+
+- shared domain/note/config helpers -> `cogstash.core...`
+- UI implementation modules -> `cogstash.ui...`
+- CLI implementation modules -> `cogstash.cli...`
+
+Internal modules should not import through:
+
+- `cogstash.search` when `cogstash.core.notes` or `cogstash.core` is the real owner
+- `cogstash.app` when `cogstash.ui.app` is the real owner
+- `cogstash.browse` or `cogstash.settings` when `cogstash.ui.browse` / `cogstash.ui.settings` is the real owner
+
+### Allowed compatibility entrypoints
+
+Some root-level imports may remain intentionally during the transition where the point of the file is to preserve a stable external launch/import surface.
+
+Current expected exception:
+
+- `src/cogstash/__main__.py` may continue to route through `cogstash.app` until the project intentionally changes that public bootstrap contract
+
+That exception should stay narrow. It does not make wrapper imports acceptable as a general internal pattern.
+
+### Test rules
+
+Tests should be split conceptually into two categories:
+
+1. **Compatibility tests**
+   - may intentionally import wrapper modules
+   - exist to verify that those shim surfaces still behave as expected
+
+2. **Owning-layer tests**
+   - should import from the real implementation module
+   - should not rely on wrappers unless wrapper behavior itself is the thing being tested
+
+This keeps wrapper coverage intentional instead of incidental.
+
+## Concrete Migration Scope
+
+### 1. Internal import cleanup in UI modules
+
+The first internal cleanup targets are:
+
+- `src/cogstash/ui/browse.py`
+- `src/cogstash/ui/settings.py`
+
+Expected direction:
+
+- move note/domain imports away from `cogstash.search` to the true core owner
+- reduce dependency on `cogstash.ui.app` for values that can live in clearer shared ownership only if that can be done without dragging in unrelated refactors
+
+Constraint:
+
+- do not force a large ownership redesign in this slice
+- if `ui.app` still legitimately owns a UI concern such as theme/window constants, it can continue to do so until a later slice extracts that concern cleanly
+
+### 2. Test migration
+
+Tests that currently import wrapper modules out of habit should move toward owning modules where they are not explicitly compatibility tests.
+
+Likely first targets:
+
+- `tests/ui/test_browse_extended.py`
+- `tests/ui/test_settings_extended.py`
+- `tests/core/test_search.py`
+- selected `tests/cli/test_cli.py` imports that reference wrapper-only paths
+
+Compatibility-focused tests such as `tests/ui/test_app_compat.py` should remain wrapper-aware if their purpose is to preserve compatibility behavior.
+
+### 3. Wrapper-module documentation
+
+Wrapper modules that remain should make their role explicit in module docstrings or comments:
+
+- compatibility shim
+- re-export owner
+- not preferred for new internal imports
+
+That avoids repeating the current ambiguity.
+
+## Alternatives Considered
+
+### 1. Remove wrappers immediately
+
+Pros:
+
+- cleanest architecture
+- no more ambiguity
+
+Cons:
+
+- mixes internal cleanup with public/API breakage
+- raises migration risk for tests and entrypoints
+- too large for the first `#12` slice
+
+Rejected for this slice.
+
+### 2. Keep wrappers and migrate only internal imports
+
+Pros:
+
+- lower immediate risk
+
+Cons:
+
+- `#21` remains underspecified
+- tests keep normalizing wrapper usage
+- compatibility surface continues to look permanent by default
+
+Rejected because it does not fully answer the wrapper-policy question.
+
+### 3. Recommended: explicit compatibility shims + direct internal imports
+
+Pros:
+
+- resolves policy ambiguity
+- improves real architecture immediately
+- keeps migration risk controlled
+
+Cons:
+
+- wrappers still exist for now
+- full cleanup remains multi-slice work
+
+Chosen.
+
+## Risks
+
+### 1. Over-migrating compatibility tests
+
+If every test is migrated away from wrappers, the compatibility surface may silently break later without detection.
+
+Mitigation:
+
+- preserve explicitly named compatibility tests
+- only migrate tests whose purpose is implementation validation rather than API compatibility
+
+### 2. Hidden ownership assumptions in `ui.app`
+
+Some values imported from `ui.app` may reflect legitimate UI ownership, while others may only live there because of history.
+
+Mitigation:
+
+- only move clearly core-owned concepts in this slice
+- defer ambiguous ownership extractions to later issues rather than forcing a large refactor here
+
+### 3. Accidental public API break
+
+Changing wrapper behavior too aggressively could break imports outside the direct test suite.
+
+Mitigation:
+
+- keep wrappers in place during this slice
+- limit changes to internal imports, test migration, and wrapper documentation
+
+## Testing Strategy
+
+This slice should add or preserve coverage for three things:
+
+1. internal code still works after direct-import cleanup
+2. migrated tests continue to pass against owning modules
+3. compatibility wrapper surfaces that intentionally remain still import and expose the expected symbols
+
+Expected verification:
+
+- targeted UI tests for browse/settings/app compatibility surfaces
+- targeted core/CLI tests affected by import-path changes
+- repository lint/type/test checks used by the project for touched areas
+
+## Success Criteria
+
+This slice is successful when:
+
+- internal modules no longer rely on wrapper/facade imports where the owning layer is obvious
+- wrapper modules that remain are clearly documented as compatibility shims
+- a meaningful subset of tests has been migrated to owning modules
+- compatibility tests remain intentional and still cover wrapper behavior where needed
+- no user-facing behavior changes
+- test/lint/type verification stays green for the touched scope
+
+## Likely Files
+
+- `src/cogstash/app.py`
+- `src/cogstash/browse.py`
+- `src/cogstash/settings.py`
+- `src/cogstash/search.py`
+- `src/cogstash/_windows.py`
+- `src/cogstash/ui/browse.py`
+- `src/cogstash/ui/settings.py`
+- `tests/core/test_search.py`
+- `tests/ui/test_browse_extended.py`
+- `tests/ui/test_settings_extended.py`
+- `tests/ui/test_app_compat.py`
+- `tests/cli/test_cli.py`

--- a/docs/superpowers/specs/2026-04-23-build-installer-artifact-contracts-design.md
+++ b/docs/superpowers/specs/2026-04-23-build-installer-artifact-contracts-design.md
@@ -1,0 +1,179 @@
+# Build And Installer Artifact Contracts Design
+
+## Context
+
+Issue `#25` is the remaining architecture-boundary slice under umbrella issue `#12`.
+
+Today, build and packaging behavior works, but artifact naming and path expectations are derived in multiple places:
+
+- `scripts/build.py`
+- `scripts/build_installer.py`
+- `.github/workflows/release.yml`
+
+Those components agree today by convention rather than by a single explicit contract. Versioned UI names, CLI names, onedir bundle paths, installer inputs, archive names, and release upload patterns are all related, but they are not owned in one place.
+
+## Goals
+
+- define one shared source of truth for artifact names and expected paths
+- reduce duplicated naming and path logic across build, installer, and release flows
+- make packaging behavior easier to evolve safely
+- keep orchestration thin and contract logic explicit
+
+## Non-Goals
+
+- redesign the release pipeline
+- change which artifact types are produced
+- change user-facing product names unless required by the existing contract
+- move packaging logic into a large configuration system
+
+## Recommended Approach
+
+Introduce one shared artifact-contract module that owns packaging identities and expected output paths.
+
+Recommended location:
+
+- `scripts/_artifacts.py`
+
+This keeps the contract close to the packaging scripts and avoids pretending that build metadata is part of the runtime application layer.
+
+The contract module should define:
+
+- canonical executable names by target and bundle mode
+- canonical onedir directory names
+- canonical installer-facing staged names
+- canonical release archive names by platform
+- helper functions for locating expected outputs under `dist/`
+
+The contract module should not run build tools itself. It should only answer questions like:
+
+- what should this artifact be called
+- where should it exist after build
+- what archive name should the workflow publish
+- what staged names should the installer consume
+
+## Ownership Boundaries
+
+### `scripts/_artifacts.py`
+
+Owns:
+
+- artifact naming rules
+- artifact path conventions
+- installer staging names
+- release archive naming rules
+- small helper APIs for locating expected outputs
+
+Does not own:
+
+- PyInstaller invocation
+- file copying or staging execution
+- Inno Setup execution
+- GitHub Actions orchestration
+
+### `scripts/build.py`
+
+Owns:
+
+- PyInstaller build plan
+- platform-specific build invocation details
+- icon conversion and build execution
+
+Consumes:
+
+- artifact names and output paths from the contract module
+
+### `scripts/build_installer.py`
+
+Owns:
+
+- finding installer inputs using the shared contract
+- staging the installer payload
+- invoking Inno Setup
+
+Consumes:
+
+- versioned bundle and binary identities from the contract module
+- stable staged-name rules from the contract module
+
+### `.github/workflows/release.yml`
+
+Owns:
+
+- validation, build, archive, upload, and release orchestration
+
+Consumes:
+
+- small Python helpers or script entrypoints that apply the shared artifact contract
+
+The workflow should stop re-deriving naming conventions inline where practical.
+
+## Contract Shape
+
+The shared module should expose a small set of explicit helpers rather than loose constants only.
+
+Examples of the contract surface:
+
+- executable name for UI onefile, UI onedir executable, and CLI onefile
+- onedir directory name for a version
+- installer staged executable names
+- platform archive name for release packaging
+- helper to locate built artifacts in `dist/`
+
+The contract should be readable enough that a maintainer can understand the packaging outputs without reading multiple scripts and workflow steps together.
+
+## Workflow Integration
+
+The release workflow currently duplicates artifact rename and archive logic inline.
+
+That should be tightened by moving naming-sensitive steps behind shared Python calls. The workflow can still orchestrate platform differences, but it should not be the place where canonical artifact identity is defined.
+
+Preferred direction:
+
+- keep YAML responsible for sequencing
+- call Python helpers/scripts for naming-sensitive operations
+
+This reduces brittle glob patterns and makes future changes easier to validate in tests.
+
+## Testing Strategy
+
+Add focused tests for the artifact contract itself.
+
+Required coverage:
+
+- expected names for UI onefile, UI onedir, and CLI artifacts
+- expected staged installer names
+- expected release archive names for each supported platform
+- expected `dist/` lookup behavior
+
+Update build and installer tests so they assert consumption of the shared contract rather than duplicated local naming logic.
+
+The workflow should be tested indirectly through script/helper behavior where possible, not by over-investing in YAML-specific tests.
+
+## Migration Plan
+
+Implement this in one focused slice:
+
+1. add the shared artifact-contract module
+2. refactor `scripts/build.py` to consume it
+3. refactor `scripts/build_installer.py` to consume it
+4. reduce duplicated rename/archive naming logic in `release.yml`
+5. add or update focused tests
+
+## Risks And Mitigations
+
+Risk: renaming logic changes accidentally and breaks release artifact compatibility.
+Mitigation: preserve current public artifact names and add direct tests for the contract.
+
+Risk: the shared module grows into an over-abstracted packaging framework.
+Mitigation: keep the module small and limited to naming/path contracts only.
+
+Risk: workflow changes become harder to read.
+Mitigation: move only naming-sensitive logic out of YAML and keep orchestration in the workflow.
+
+## Acceptance Criteria
+
+- artifact naming and path conventions are defined in one shared module
+- `build.py` and `build_installer.py` no longer duplicate core artifact naming rules
+- release workflow logic relies less on inline artifact naming conventions
+- tests directly cover the shared artifact contract
+- current external artifact names remain stable unless explicitly changed

--- a/scripts/_artifacts.py
+++ b/scripts/_artifacts.py
@@ -1,0 +1,89 @@
+"""Shared artifact naming and path contract for CogStash packaging."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+APP_NAME = "CogStash"
+CLI_NAME = "CogStash-CLI"
+
+STAGED_APP_DIRNAME = APP_NAME
+STAGED_UI_EXE_NAME = f"{APP_NAME}.exe"
+STAGED_CLI_EXE_NAME = f"{CLI_NAME}.exe"
+
+
+def get_executable_name(*, target: str, bundle_mode: str, version: str) -> str:
+    """Return the canonical versioned executable name for a build target."""
+    if target == "ui":
+        if bundle_mode == "onefile":
+            return f"{APP_NAME}-{version}"
+        if bundle_mode == "onedir":
+            return f"{APP_NAME}-{version}-onedir"
+        raise ValueError(f"Unknown bundle mode: {bundle_mode}")
+    if target == "cli":
+        return f"{CLI_NAME}-{version}"
+    raise ValueError(f"Unknown target: {target}")
+
+
+def get_onedir_dir_name(version: str) -> str:
+    """Return the canonical versioned onedir directory name."""
+    return get_executable_name(target="ui", bundle_mode="onedir", version=version)
+
+
+def get_onedir_exe_name(version: str) -> str:
+    """Return the executable name inside a versioned onedir bundle."""
+    return f"{get_onedir_dir_name(version)}.exe"
+
+
+def get_cli_exe_name(version: str) -> str:
+    """Return the canonical Windows CLI executable name."""
+    return f"{get_executable_name(target='cli', bundle_mode='onefile', version=version)}.exe"
+
+
+def get_staged_app_dirname() -> str:
+    """Return the versionless installer staging directory name."""
+    return STAGED_APP_DIRNAME
+
+
+def get_staged_ui_exe_name() -> str:
+    """Return the UI executable name inside the installer staging directory."""
+    return STAGED_UI_EXE_NAME
+
+
+def get_staged_cli_exe_name() -> str:
+    """Return the CLI executable name inside the installer staging directory."""
+    return STAGED_CLI_EXE_NAME
+
+
+def get_release_archive_name(*, tag: str, platform_suffix: str) -> str:
+    """Return the release archive filename for a tag and platform."""
+    if platform_suffix == "windows":
+        return f"{APP_NAME}-{tag}-windows.zip"
+    if platform_suffix == "macos":
+        return f"{APP_NAME}-{tag}-macos.zip"
+    if platform_suffix == "linux":
+        return f"{APP_NAME}-{tag}-linux.tar.gz"
+    raise ValueError(f"Unknown platform suffix: {platform_suffix}")
+
+
+@dataclass(frozen=True, slots=True)
+class WindowsArtifactLayout:
+    """Paths and staged names for Windows build and installer artifacts."""
+
+    onedir_dir: Path
+    onedir_exe: Path
+    cli_exe: Path
+    staged_app_dirname: str = STAGED_APP_DIRNAME
+    staged_ui_exe_name: str = STAGED_UI_EXE_NAME
+    staged_cli_exe_name: str = STAGED_CLI_EXE_NAME
+
+
+def windows_artifact_layout(*, version: str, dist_dir: Path) -> WindowsArtifactLayout:
+    """Return the expected Windows build layout under ``dist_dir``."""
+    onedir_dir = dist_dir / get_onedir_dir_name(version)
+    return WindowsArtifactLayout(
+        onedir_dir=onedir_dir,
+        onedir_exe=onedir_dir / get_onedir_exe_name(version),
+        cli_exe=dist_dir / get_cli_exe_name(version),
+    )

--- a/scripts/_artifacts.py
+++ b/scripts/_artifacts.py
@@ -67,7 +67,7 @@ def get_release_archive_name(*, tag: str, platform_suffix: str) -> str:
     raise ValueError(f"Unknown platform suffix: {platform_suffix}")
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class WindowsArtifactLayout:
     """Paths and staged names for Windows build and installer artifacts."""
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from _artifacts import get_executable_name
+
 ROOT = Path(__file__).resolve().parent.parent
 ICON_SRC = ROOT / "assets" / "cogstash_icon.png"
 BUILD_DIR = ROOT / "build"
@@ -50,15 +52,6 @@ def get_hidden_imports(target: str) -> list[str]:
         return UI_HIDDEN_IMPORTS
     if target == "cli":
         return CLI_HIDDEN_IMPORTS
-    raise ValueError(f"Unknown target: {target}")
-
-
-def get_executable_name(*, target: str, bundle_mode: str, version: str) -> str:
-    """Return the versioned output name for a target/bundle combination."""
-    if target == "ui":
-        return f"CogStash-{version}" if bundle_mode == "onefile" else f"CogStash-{version}-onedir"
-    if target == "cli":
-        return f"CogStash-CLI-{version}"
     raise ValueError(f"Unknown target: {target}")
 
 

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -10,33 +10,22 @@ import subprocess
 from importlib.metadata import version as package_version
 from pathlib import Path
 
+from _artifacts import (
+    get_staged_app_dirname,
+    get_staged_cli_exe_name,
+    get_staged_ui_exe_name,
+    windows_artifact_layout,
+)
+
 ROOT = Path(__file__).resolve().parent.parent
 BUILD_DIR = ROOT / "build"
 DIST_DIR = ROOT / "dist"
 ISS_PATH = ROOT / "installer" / "windows" / "CogStash.iss"
-STAGED_APP_DIRNAME = "CogStash"
-STAGED_EXE_NAME = "CogStash.exe"
-STAGED_CLI_EXE_NAME = "CogStash-CLI.exe"
 
 
 def get_version() -> str:
     """Get the installed package version."""
     return package_version("cogstash")
-
-
-def get_onedir_dir_name(version: str) -> str:
-    """Return the expected versioned onedir folder name."""
-    return f"CogStash-{version}-onedir"
-
-
-def get_onedir_exe_name(version: str) -> str:
-    """Return the expected versioned onedir executable name."""
-    return f"{get_onedir_dir_name(version)}.exe"
-
-
-def get_cli_exe_name(version: str) -> str:
-    """Return the expected versioned CLI executable name."""
-    return f"CogStash-CLI-{version}.exe"
 
 
 def make_version_info_version(version: str) -> str:
@@ -50,11 +39,12 @@ def make_version_info_version(version: str) -> str:
 
 def find_windows_onedir_bundle(dist_dir: Path, version: str) -> Path:
     """Locate the Windows onedir bundle created by scripts/build.py."""
-    bundle_dir = dist_dir / get_onedir_dir_name(version)
+    layout = windows_artifact_layout(version=version, dist_dir=dist_dir)
+    bundle_dir = layout.onedir_dir
     if not bundle_dir.is_dir():
         raise FileNotFoundError(f"Windows onedir bundle not found: {bundle_dir}")
 
-    bundle_exe = bundle_dir / get_onedir_exe_name(version)
+    bundle_exe = layout.onedir_exe
     if not bundle_exe.is_file():
         raise FileNotFoundError(f"Expected bundle executable not found: {bundle_exe}")
 
@@ -63,7 +53,7 @@ def find_windows_onedir_bundle(dist_dir: Path, version: str) -> Path:
 
 def find_windows_cli_binary(dist_dir: Path, version: str) -> Path:
     """Locate the Windows CLI onefile binary created by scripts/build.py."""
-    cli_binary = dist_dir / get_cli_exe_name(version)
+    cli_binary = windows_artifact_layout(version=version, dist_dir=dist_dir).cli_exe
     if not cli_binary.is_file():
         raise FileNotFoundError(f"Windows CLI binary not found: {cli_binary}")
     return cli_binary
@@ -71,17 +61,18 @@ def find_windows_cli_binary(dist_dir: Path, version: str) -> Path:
 
 def stage_windows_payload(*, bundle_dir: Path, cli_binary: Path, version: str, staging_root: Path) -> Path:
     """Copy the versioned onedir bundle into a versionless installer payload."""
-    staged_dir = staging_root / STAGED_APP_DIRNAME
+    layout = windows_artifact_layout(version=version, dist_dir=bundle_dir.parent)
+    staged_dir = staging_root / get_staged_app_dirname()
     if staged_dir.exists():
         shutil.rmtree(staged_dir)
 
     staging_root.mkdir(parents=True, exist_ok=True)
     shutil.copytree(bundle_dir, staged_dir)
 
-    versioned_exe = staged_dir / get_onedir_exe_name(version)
-    staged_exe = staged_dir / STAGED_EXE_NAME
+    versioned_exe = staged_dir / layout.onedir_exe.name
+    staged_exe = staged_dir / get_staged_ui_exe_name()
     versioned_exe.rename(staged_exe)
-    shutil.copy2(cli_binary, staged_dir / STAGED_CLI_EXE_NAME)
+    shutil.copy2(cli_binary, staged_dir / get_staged_cli_exe_name())
     return staged_dir
 
 

--- a/src/cogstash/_windows.py
+++ b/src/cogstash/_windows.py
@@ -1,3 +1,10 @@
+"""Compatibility shim for the legacy ``cogstash._windows`` import surface.
+
+The owning implementations live in ``cogstash.cli.windows`` and
+``cogstash.ui.windows``. Keep this module as a narrow compatibility layer while
+internal code imports the owning modules directly.
+"""
+
 from __future__ import annotations
 
 from cogstash.cli.windows import prepare_windows_cli_console

--- a/src/cogstash/app.py
+++ b/src/cogstash/app.py
@@ -1,8 +1,8 @@
-"""
-cogstash.py — A global hotkey brain dump — press, type, gone.
-Hotkey: Ctrl + Shift + Space
-Enter  → appends timestamped note to cogstash.md
-Escape → hides window
+"""Compatibility shim for the legacy ``cogstash.app`` import surface.
+
+The owning implementation lives in ``cogstash.ui.app``. Keep this module as a
+temporary re-export layer for compatibility while internal code imports the UI
+module directly.
 """
 
 from __future__ import annotations

--- a/src/cogstash/browse.py
+++ b/src/cogstash/browse.py
@@ -1,3 +1,10 @@
+"""Compatibility shim for the legacy ``cogstash.browse`` import surface.
+
+The owning implementation lives in ``cogstash.ui.browse``. Keep this module as
+a temporary re-export layer for compatibility while internal code imports the
+UI module directly.
+"""
+
 from __future__ import annotations
 
 from cogstash.ui.browse import *  # noqa: F401,F403

--- a/src/cogstash/search.py
+++ b/src/cogstash/search.py
@@ -1,4 +1,9 @@
-"""Compatibility wrapper for shared note helpers."""
+"""Compatibility shim for the legacy ``cogstash.search`` import surface.
+
+The owning implementation lives in ``cogstash.core.notes``. Keep this module
+as a temporary re-export layer for compatibility while internal code imports
+the core module directly.
+"""
 
 from __future__ import annotations
 

--- a/src/cogstash/settings.py
+++ b/src/cogstash/settings.py
@@ -1,3 +1,10 @@
+"""Compatibility shim for the legacy ``cogstash.settings`` import surface.
+
+The owning implementation lives in ``cogstash.ui.settings``. Keep this module
+as a temporary re-export layer for compatibility while internal code imports
+the UI module directly.
+"""
+
 from __future__ import annotations
 
 from cogstash.ui.settings import *  # noqa: F401,F403

--- a/src/cogstash/ui/app.py
+++ b/src/cogstash/ui/app.py
@@ -8,9 +8,7 @@ Escape → hides window
 from __future__ import annotations
 
 import logging
-import os
 import queue
-import subprocess
 import sys
 import threading
 import tkinter as tk
@@ -30,6 +28,7 @@ from cogstash.core import (
     save_config,
 )
 from cogstash.core import parse_smart_tags as _parse_smart_tags
+from cogstash.ui import windows_runtime
 
 parse_smart_tags = _parse_smart_tags
 
@@ -94,13 +93,8 @@ def platform_font() -> str:
 
 
 def configure_dpi() -> None:
-    """Enable DPI awareness on Windows so the UI renders crisply on HiDPI displays."""
-    if sys.platform == "win32":
-        try:
-            import ctypes
-            ctypes.windll.shcore.SetProcessDpiAwareness(1)
-        except (AttributeError, OSError):
-            pass
+    """Compatibility forwarder for UI Windows runtime DPI setup."""
+    windows_runtime.configure_dpi()
 
 
 def create_tray_icon(app_queue: queue.Queue, config: CogStashConfig) -> None:
@@ -140,13 +134,7 @@ def create_tray_icon(app_queue: queue.Queue, config: CogStashConfig) -> None:
         draw.text((x, y), "⚡", fill=hex_to_rgba(theme["fg"]), font=font)
 
     def open_notes():
-        path = str(config.output_file)
-        if sys.platform == "win32":
-            os.startfile(path)
-        elif sys.platform == "darwin":
-            subprocess.run(["open", path], check=False)
-        else:
-            subprocess.run(["xdg-open", path], check=False)
+        windows_runtime.open_target_in_shell(str(config.output_file))
 
     def quit_app(icon):
         icon.stop()

--- a/src/cogstash/ui/app.py
+++ b/src/cogstash/ui/app.py
@@ -10,13 +10,10 @@ from __future__ import annotations
 import logging
 import queue
 import sys
-import threading
 import tkinter as tk
 from pathlib import Path
 from tkinter import messagebox
 from typing import Any
-
-from pynput import keyboard
 
 from cogstash.core import (
     DEFAULT_SMART_TAGS,
@@ -28,7 +25,7 @@ from cogstash.core import (
     save_config,
 )
 from cogstash.core import parse_smart_tags as _parse_smart_tags
-from cogstash.ui import windows_runtime
+from cogstash.ui import app_runtime, windows_runtime
 
 parse_smart_tags = _parse_smart_tags
 
@@ -97,78 +94,13 @@ def configure_dpi() -> None:
     windows_runtime.configure_dpi()
 
 
-def create_tray_icon(app_queue: queue.Queue, config: CogStashConfig) -> None:
-    """Create and run a system tray icon on a daemon thread."""
-    try:
-        import pystray
-        from PIL import Image, ImageDraw, ImageFont
-    except ImportError:
-        logger.warning("pystray or Pillow not installed — skipping tray icon")
-        return
-
-    theme = THEMES[config.theme]
-    # Parse hex color to RGBA tuple
-    def hex_to_rgba(h):
-        h = h.lstrip("#")
-        return tuple(int(h[i:i+2], 16) for i in (0, 2, 4)) + (255,)
-
-    # Try bundled icon first (PyInstaller frozen binary)
-    img = None
-    if getattr(sys, "frozen", False):
-        bundle_dir = Path(getattr(sys, "_MEIPASS", "."))
-        icon_path = bundle_dir / "assets" / "cogstash_icon.png"
-        if icon_path.exists():
-            img = Image.open(icon_path).resize((64, 64))
-
-    if img is None:
-        # Fallback: generate icon programmatically
-        img = Image.new("RGBA", (64, 64), hex_to_rgba(theme["bg"]))
-        draw = ImageDraw.Draw(img)
-        try:
-            font: ImageFont.FreeTypeFont | ImageFont.ImageFont = ImageFont.truetype("arial", 40)
-        except OSError:
-            font = ImageFont.load_default()
-        bbox = draw.textbbox((0, 0), "⚡", font=font)
-        x = (64 - (bbox[2] - bbox[0])) // 2 - bbox[0]
-        y = (64 - (bbox[3] - bbox[1])) // 2 - bbox[1]
-        draw.text((x, y), "⚡", fill=hex_to_rgba(theme["fg"]), font=font)
-
-    def open_notes():
-        windows_runtime.open_target_in_shell(str(config.output_file))
-
-    def quit_app(icon):
-        icon.stop()
-        app_queue.put("QUIT")
-
-    def browse_notes():
-        app_queue.put("BROWSE")
-
-    def open_settings():
-        app_queue.put("SETTINGS")
-
-    assert config.output_file is not None, "output_file should be set by __post_init__"
-    menu = pystray.Menu(
-        pystray.MenuItem("CogStash ⚡", None, enabled=False),
-        pystray.Menu.SEPARATOR,
-        pystray.MenuItem(f"Open {config.output_file.name}", lambda: open_notes()),
-        pystray.MenuItem("Browse Notes", lambda: browse_notes()),
-        pystray.MenuItem("Settings", lambda: open_settings()),
-        pystray.Menu.SEPARATOR,
-        pystray.MenuItem("Quit", quit_app),
-    )
-
-    icon = pystray.Icon("cogstash", img, "CogStash", menu)
-    thread = threading.Thread(target=icon.run, daemon=True)
-    thread.start()
-
-
 class CogStash:
     def __init__(self, root: tk.Tk, config: CogStashConfig, config_path: Path | None = None):
         self.root = root
         self.config = config
         self.config_path = config_path or get_default_config_path()
         self.hotkey_warning: str | None = None
-        self.queue: queue.Queue[str] = queue.Queue()
+        self.queue: queue.Queue[app_runtime.AppCommand] = queue.Queue()
         self.is_visible = False
         self.theme = THEMES[config.theme]
         self.win_size = WINDOW_SIZES[config.window_size]
@@ -390,21 +322,15 @@ class CogStash:
 
     def poll_queue(self):
         """Check the queue for messages from the pynput/tray threads."""
-        try:
-            while True:
-                msg = self.queue.get_nowait()
-                if msg == "SHOW":
-                    self.show_window()
-                elif msg == "BROWSE":
-                    self._open_browse()
-                elif msg == "SETTINGS":
-                    self._open_settings()
-                elif msg == "QUIT":
-                    self.root.quit()
-                    return
-        except queue.Empty:
-            pass
-        self.root.after(100, self.poll_queue)
+        should_continue = app_runtime.drain_app_queue(
+            self.queue,
+            on_show=self.show_window,
+            on_browse=self._open_browse,
+            on_settings=self._open_settings,
+            on_quit=self.root.quit,
+        )
+        if should_continue:
+            self.root.after(100, self.poll_queue)
 
     def _open_browse(self):
         """Open the Browse Notes window."""
@@ -559,14 +485,10 @@ def main():
     app = CogStash(root, config)
     app.config_path = config_path
 
-    create_tray_icon(app.queue, config)
-
-    def on_hotkey():
-        app.queue.put("SHOW")
+    runtime_handles = app_runtime.start_runtime(app.queue, config, themes=THEMES)
 
     try:
-        listener = keyboard.GlobalHotKeys({config.hotkey: on_hotkey})
-        listener.start()
+        runtime_handles.hotkey_listener = app_runtime.start_hotkey_listener(app.queue, config.hotkey)
     except Exception:
         app.hotkey_warning = _build_hotkey_failure_warning(config)
         logger.error("Failed to register global hotkey %s", config.hotkey, exc_info=True)
@@ -575,15 +497,13 @@ def main():
             messagebox.showwarning("CogStash Hotkey Warning", app.hotkey_warning)
         except tk.TclError:
             pass
-        listener = None
 
     try:
         root.mainloop()
     except KeyboardInterrupt:
         safe_print("\nCogStash stopped.")
     finally:
-        if listener is not None:
-            listener.stop()
+        app_runtime.shutdown_runtime(runtime_handles)
         instance_guard.close()
 
 

--- a/src/cogstash/ui/app_runtime.py
+++ b/src/cogstash/ui/app_runtime.py
@@ -47,7 +47,7 @@ def enqueue_command(app_queue: queue.Queue[AppCommand], command: AppCommand) -> 
 
 
 def drain_app_queue(
-    app_queue: queue.Queue[object],
+    app_queue: queue.Queue[AppCommand],
     *,
     on_show: Callable[[], None],
     on_browse: Callable[[], None],
@@ -55,6 +55,9 @@ def drain_app_queue(
     on_quit: Callable[[], None],
 ) -> bool:
     """Drain pending commands and dispatch them through explicit callbacks.
+
+    Only ``AppCommand`` values are recognized. Legacy raw strings are
+    intentionally treated as unknown commands and ignored.
 
     Returns False when QUIT is observed so the caller can stop rescheduling the
     poll loop.

--- a/src/cogstash/ui/app_runtime.py
+++ b/src/cogstash/ui/app_runtime.py
@@ -1,0 +1,191 @@
+"""Runtime boundary for CogStash UI queue and background integrations."""
+
+from __future__ import annotations
+
+import logging
+import queue
+import sys
+import threading
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Callable
+
+from cogstash.core import CogStashConfig
+from cogstash.ui import windows_runtime
+
+try:
+    from pynput import keyboard
+except Exception:  # pragma: no cover - exercised only when dependency is absent
+    keyboard = SimpleNamespace(GlobalHotKeys=None, HotKey=SimpleNamespace(parse=lambda _value: None))
+
+logger = logging.getLogger("cogstash")
+
+
+class AppCommand(str, Enum):
+    """Commands that background UI integrations can send to the Tk thread."""
+
+    SHOW = "SHOW"
+    BROWSE = "BROWSE"
+    SETTINGS = "SETTINGS"
+    QUIT = "QUIT"
+
+
+@dataclass
+class AppRuntimeHandles:
+    """Resources that need coordinated shutdown."""
+
+    tray_icon: object | None = None
+    hotkey_listener: object | None = None
+
+
+def enqueue_command(app_queue: queue.Queue[AppCommand], command: AppCommand) -> None:
+    """Put a runtime command onto the shared UI queue."""
+
+    app_queue.put(command)
+
+
+def drain_app_queue(
+    app_queue: queue.Queue[object],
+    *,
+    on_show: Callable[[], None],
+    on_browse: Callable[[], None],
+    on_settings: Callable[[], None],
+    on_quit: Callable[[], None],
+) -> bool:
+    """Drain pending commands and dispatch them through explicit callbacks.
+
+    Returns False when QUIT is observed so the caller can stop rescheduling the
+    poll loop.
+    """
+
+    while True:
+        try:
+            command = app_queue.get_nowait()
+        except queue.Empty:
+            return True
+
+        if command == AppCommand.SHOW:
+            on_show()
+        elif command == AppCommand.BROWSE:
+            on_browse()
+        elif command == AppCommand.SETTINGS:
+            on_settings()
+        elif command == AppCommand.QUIT:
+            on_quit()
+            return False
+        else:
+            logger.warning("Ignoring unknown app command: %r", command)
+
+
+def start_hotkey_listener(
+    app_queue: queue.Queue[AppCommand],
+    hotkey: str,
+):
+    """Start the global hotkey listener that enqueues the SHOW command."""
+
+    if not hasattr(keyboard, "GlobalHotKeys") or keyboard.GlobalHotKeys is None:
+        raise RuntimeError("pynput keyboard hotkeys are unavailable")
+
+    listener = keyboard.GlobalHotKeys({hotkey: lambda: enqueue_command(app_queue, AppCommand.SHOW)})
+    listener.start()
+    return listener
+
+
+def _create_tray_image(theme: dict[str, str]):
+    """Build the tray icon image, using the bundled asset when available."""
+
+    from PIL import Image, ImageDraw, ImageFont
+
+    def hex_to_rgba(hex_color: str) -> tuple[int, int, int, int]:
+        value = hex_color.lstrip("#")
+        return tuple(int(value[index : index + 2], 16) for index in (0, 2, 4)) + (255,)
+
+    img = None
+    if getattr(sys, "frozen", False):
+        bundle_dir = Path(getattr(sys, "_MEIPASS", "."))
+        icon_path = bundle_dir / "assets" / "cogstash_icon.png"
+        if icon_path.exists():
+            img = Image.open(icon_path).resize((64, 64))
+
+    if img is None:
+        img = Image.new("RGBA", (64, 64), hex_to_rgba(theme["bg"]))
+        draw = ImageDraw.Draw(img)
+        try:
+            font: ImageFont.FreeTypeFont | ImageFont.ImageFont = ImageFont.truetype("arial", 40)
+        except OSError:
+            font = ImageFont.load_default()
+        bbox = draw.textbbox((0, 0), "⚡", font=font)
+        x = (64 - (bbox[2] - bbox[0])) // 2 - bbox[0]
+        y = (64 - (bbox[3] - bbox[1])) // 2 - bbox[1]
+        draw.text((x, y), "⚡", fill=hex_to_rgba(theme["fg"]), font=font)
+
+    return img
+
+
+def start_tray_icon(
+    app_queue: queue.Queue[AppCommand],
+    config: CogStashConfig,
+    *,
+    themes: dict[str, dict[str, str]],
+):
+    """Start the system tray icon on a daemon thread, if dependencies exist."""
+
+    try:
+        import pystray
+    except ImportError:
+        logger.warning("pystray or Pillow not installed — skipping tray icon")
+        return None
+
+    theme = themes[config.theme]
+    img = _create_tray_image(theme)
+
+    def open_notes() -> None:
+        assert config.output_file is not None, "output_file should be set by __post_init__"
+        windows_runtime.open_target_in_shell(str(config.output_file))
+
+    def browse_notes() -> None:
+        enqueue_command(app_queue, AppCommand.BROWSE)
+
+    def open_settings() -> None:
+        enqueue_command(app_queue, AppCommand.SETTINGS)
+
+    def quit_app(icon) -> None:
+        icon.stop()
+        enqueue_command(app_queue, AppCommand.QUIT)
+
+    assert config.output_file is not None, "output_file should be set by __post_init__"
+    menu = pystray.Menu(
+        pystray.MenuItem("CogStash ⚡", None, enabled=False),
+        pystray.Menu.SEPARATOR,
+        pystray.MenuItem(f"Open {config.output_file.name}", lambda: open_notes()),
+        pystray.MenuItem("Browse Notes", lambda: browse_notes()),
+        pystray.MenuItem("Settings", lambda: open_settings()),
+        pystray.Menu.SEPARATOR,
+        pystray.MenuItem("Quit", quit_app),
+    )
+
+    icon = pystray.Icon("cogstash", img, "CogStash", menu)
+    threading.Thread(target=icon.run, daemon=True).start()
+    return icon
+
+
+def start_runtime(
+    app_queue: queue.Queue[AppCommand],
+    config: CogStashConfig,
+    *,
+    themes: dict[str, dict[str, str]],
+) -> AppRuntimeHandles:
+    """Start runtime integrations and return their shutdown handles."""
+
+    return AppRuntimeHandles(tray_icon=start_tray_icon(app_queue, config, themes=themes))
+
+
+def shutdown_runtime(handles: AppRuntimeHandles) -> None:
+    """Stop runtime integrations if they were started."""
+
+    if handles.tray_icon is not None:
+        handles.tray_icon.stop()
+    if handles.hotkey_listener is not None:
+        handles.hotkey_listener.stop()

--- a/src/cogstash/ui/app_runtime.py
+++ b/src/cogstash/ui/app_runtime.py
@@ -66,13 +66,13 @@ def drain_app_queue(
         except queue.Empty:
             return True
 
-        if command == AppCommand.SHOW:
+        if command is AppCommand.SHOW:
             on_show()
-        elif command == AppCommand.BROWSE:
+        elif command is AppCommand.BROWSE:
             on_browse()
-        elif command == AppCommand.SETTINGS:
+        elif command is AppCommand.SETTINGS:
             on_settings()
-        elif command == AppCommand.QUIT:
+        elif command is AppCommand.QUIT:
             on_quit()
             return False
         else:

--- a/src/cogstash/ui/app_runtime.py
+++ b/src/cogstash/ui/app_runtime.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Callable
+from typing import Callable, Protocol
 
 from cogstash.core import CogStashConfig
 from cogstash.ui import windows_runtime
@@ -21,6 +21,12 @@ except Exception:  # pragma: no cover - exercised only when dependency is absent
     keyboard = SimpleNamespace(GlobalHotKeys=None, HotKey=SimpleNamespace(parse=lambda _value: None))
 
 logger = logging.getLogger("cogstash")
+
+
+class _StopHandle(Protocol):
+    """Object that can be stopped during runtime shutdown."""
+
+    def stop(self) -> None: ...
 
 
 class AppCommand(str, Enum):
@@ -36,8 +42,8 @@ class AppCommand(str, Enum):
 class AppRuntimeHandles:
     """Resources that need coordinated shutdown."""
 
-    tray_icon: object | None = None
-    hotkey_listener: object | None = None
+    tray_icon: _StopHandle | None = None
+    hotkey_listener: _StopHandle | None = None
 
 
 def enqueue_command(app_queue: queue.Queue[AppCommand], command: AppCommand) -> None:
@@ -103,7 +109,10 @@ def _create_tray_image(theme: dict[str, str]):
 
     def hex_to_rgba(hex_color: str) -> tuple[int, int, int, int]:
         value = hex_color.lstrip("#")
-        return tuple(int(value[index : index + 2], 16) for index in (0, 2, 4)) + (255,)
+        red = int(value[0:2], 16)
+        green = int(value[2:4], 16)
+        blue = int(value[4:6], 16)
+        return (red, green, blue, 255)
 
     img = None
     if getattr(sys, "frozen", False):

--- a/src/cogstash/ui/browse.py
+++ b/src/cogstash/ui/browse.py
@@ -11,10 +11,11 @@ import sys
 import tkinter as tk
 from datetime import datetime, timedelta
 
-from cogstash.search import (
+from cogstash.core import (
+    DEFAULT_SMART_TAGS,
     DEFAULT_TAG_COLORS,
+    CogStashConfig,
     Note,
-    _atomic_write,
     delete_note,
     edit_note,
     filter_by_tag,
@@ -22,7 +23,8 @@ from cogstash.search import (
     parse_notes,
     search_notes,
 )
-from cogstash.ui.app import DEFAULT_SMART_TAGS, THEMES, CogStashConfig, platform_font
+from cogstash.core.notes import _atomic_write
+from cogstash.ui.app import THEMES, platform_font
 
 
 class BrowseWindow:

--- a/src/cogstash/ui/settings.py
+++ b/src/cogstash/ui/settings.py
@@ -9,15 +9,12 @@ from tkinter import messagebox
 
 from pynput import keyboard
 
+from cogstash.core import DEFAULT_SMART_TAGS, CogStashConfig, merge_tags, save_config
 from cogstash.ui.app import (
-    DEFAULT_SMART_TAGS,
     THEMES,
     WINDOW_SIZES,
-    CogStashConfig,
     logger,
-    merge_tags,
     platform_font,
-    save_config,
 )
 from cogstash.ui.install_state import get_startup_shortcut_path
 

--- a/src/cogstash/ui/settings.py
+++ b/src/cogstash/ui/settings.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 import tkinter as tk
 from pathlib import Path
 from tkinter import messagebox
@@ -10,13 +9,12 @@ from tkinter import messagebox
 from pynput import keyboard
 
 from cogstash.core import DEFAULT_SMART_TAGS, CogStashConfig, merge_tags, save_config
+from cogstash.ui import windows_runtime
 from cogstash.ui.app import (
     THEMES,
     WINDOW_SIZES,
-    logger,
     platform_font,
 )
-from cogstash.ui.install_state import get_startup_shortcut_path
 
 
 def validate_hotkey(value: str) -> tuple[bool, str | None]:
@@ -32,31 +30,6 @@ def validate_hotkey(value: str) -> tuple[bool, str | None]:
             "<ctrl>+<alt>+h."
         )
     return True, None
-
-
-def set_launch_at_startup(enable: bool) -> None:
-    """Enable or disable launch at system startup (Windows only)."""
-    if sys.platform != "win32":
-        return
-    shortcut_path = get_startup_shortcut_path()
-    if enable:
-        exe = sys.executable
-        if getattr(sys, "frozen", False):
-            exe = sys.argv[0]
-            content = f'@echo off\nstart "" "{exe}"\n'
-        else:
-            content = f'@echo off\nstart "" "{exe}" -m cogstash.ui\n'
-        try:
-            shortcut_path.parent.mkdir(parents=True, exist_ok=True)
-            shortcut_path.write_text(content, encoding="utf-8")
-        except OSError:
-            logger.error("Failed to create startup shortcut", exc_info=True)
-    else:
-        try:
-            if shortcut_path.exists():
-                shortcut_path.unlink()
-        except OSError:
-            logger.error("Failed to remove startup shortcut", exc_info=True)
 
 
 class SettingsWindow:
@@ -228,7 +201,7 @@ class SettingsWindow:
         tk.Label(frame, text="Startup", bg=t["bg"], fg=t["fg"],
                  font=(platform_font(), 11, "bold")).pack(anchor="w", pady=(16, 4))
         # Reflect actual on-disk state so installer-created scripts are visible immediately.
-        if sys.platform == "win32":
+        if windows_runtime.sys.platform == "win32":
             from cogstash.ui.install_state import startup_script_exists  # lazy — keeps install_state optional
 
             startup_state = startup_script_exists()
@@ -272,7 +245,7 @@ class SettingsWindow:
         self.config.output_file = Path(self.notes_file_var.get()).expanduser()
         new_launch = self.launch_var.get()
         if new_launch != self.config.launch_at_startup:
-            set_launch_at_startup(new_launch)
+            windows_runtime.set_launch_at_startup(new_launch)
         self.config.launch_at_startup = new_launch
         save_config(self.config, self.config_path)
         self._flash_saved()
@@ -492,17 +465,7 @@ class SettingsWindow:
 
     def _open_link(self, target: str):
         """Open a URL or file path."""
-        import os
-        import subprocess
-        if target.startswith("http"):
-            import webbrowser
-            webbrowser.open(target)
-        elif sys.platform == "win32":
-            os.startfile(target)
-        elif sys.platform == "darwin":
-            subprocess.run(["open", target], check=False)
-        else:
-            subprocess.run(["xdg-open", target], check=False)
+        windows_runtime.open_target_in_shell(target)
 
     def _render_tags(self):
         """Render the tag list in the tags tab."""

--- a/src/cogstash/ui/windows_runtime.py
+++ b/src/cogstash/ui/windows_runtime.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+
+from cogstash.ui.install_state import get_startup_shortcut_path
+
+logger = logging.getLogger("cogstash")
+
+
+def configure_dpi() -> None:
+    """Enable DPI awareness on Windows so the UI renders crisply on HiDPI displays."""
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes
+
+        ctypes.windll.shcore.SetProcessDpiAwareness(1)
+    except (AttributeError, OSError):
+        pass
+
+
+def open_target_in_shell(target: str) -> None:
+    """Open a URL or file path via the native platform shell."""
+    if target.startswith("http"):
+        import webbrowser
+
+        webbrowser.open(target)
+        return
+
+    if sys.platform == "win32":
+        os.startfile(target)
+        return
+    if sys.platform == "darwin":
+        subprocess.run(["open", target], check=False)
+        return
+    subprocess.run(["xdg-open", target], check=False)
+
+
+def set_launch_at_startup(enable: bool) -> None:
+    """Enable or disable launch at system startup (Windows only)."""
+    if sys.platform != "win32":
+        return
+
+    shortcut_path = get_startup_shortcut_path()
+    if enable:
+        exe = sys.executable
+        if getattr(sys, "frozen", False):
+            exe = sys.argv[0]
+            content = f'@echo off\nstart "" "{exe}"\n'
+        else:
+            content = f'@echo off\nstart "" "{exe}" -m cogstash.ui\n'
+        try:
+            shortcut_path.parent.mkdir(parents=True, exist_ok=True)
+            shortcut_path.write_text(content, encoding="utf-8")
+        except OSError:
+            logger.error("Failed to create startup shortcut", exc_info=True)
+        return
+
+    try:
+        if shortcut_path.exists():
+            shortcut_path.unlink()
+    except OSError:
+        logger.error("Failed to remove startup shortcut", exc_info=True)
+
+
+__all__ = ["configure_dpi", "open_target_in_shell", "set_launch_at_startup"]

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -21,7 +21,7 @@ def _make_notes_file(tmp_path):
 def test_format_note_color():
     """ANSI escape codes present when use_color=True."""
     from cogstash.cli import format_note
-    from cogstash.search import Note
+    from cogstash.core import Note
 
     note = Note(
         index=1,
@@ -38,7 +38,7 @@ def test_format_note_color():
 def test_format_note_plain():
     """No ANSI codes when use_color=False."""
     from cogstash.cli import format_note
-    from cogstash.search import Note
+    from cogstash.core import Note
 
     note = Note(
         index=1,
@@ -55,7 +55,7 @@ def test_format_note_plain():
 def test_format_done_note():
     """Done notes get strikethrough + dimmed styling."""
     from cogstash.cli import format_note
-    from cogstash.search import Note
+    from cogstash.core import Note
 
     note = Note(
         index=1,
@@ -305,7 +305,7 @@ def test_format_note_custom_tag(tmp_path):
     from datetime import datetime
 
     from cogstash.cli import format_note
-    from cogstash.search import Note
+    from cogstash.core import Note
 
     note = Note(
         index=1,

--- a/tests/core/test_search.py
+++ b/tests/core/test_search.py
@@ -2,6 +2,7 @@
 
 import builtins
 from datetime import datetime
+from pathlib import Path
 
 
 def test_parse_notes_basic(tmp_path):
@@ -9,7 +10,7 @@ def test_parse_notes_basic(tmp_path):
     f = tmp_path / "cogstash.md"
     f.write_text("- [2026-03-26 14:30] ☐ buy milk #todo\n", encoding="utf-8")
 
-    from cogstash.search import parse_notes
+    from cogstash.core.notes import parse_notes
     notes = parse_notes(f)
 
     assert len(notes) == 1
@@ -32,7 +33,7 @@ def test_parse_notes_multiline(tmp_path):
         encoding="utf-8",
     )
 
-    from cogstash.search import parse_notes
+    from cogstash.core.notes import parse_notes
     notes = parse_notes(f)
 
     assert len(notes) == 1
@@ -41,7 +42,7 @@ def test_parse_notes_multiline(tmp_path):
 
 def test_parse_notes_missing_file(tmp_path):
     """Missing file returns empty list."""
-    from cogstash.search import parse_notes
+    from cogstash.core.notes import parse_notes
     notes = parse_notes(tmp_path / "nonexistent.md")
     assert notes == []
 
@@ -51,7 +52,7 @@ def test_parse_notes_no_prefix(tmp_path):
     f = tmp_path / "cogstash.md"
     f.write_text("- [2026-03-26 14:30] plain note\n", encoding="utf-8")
 
-    from cogstash.search import parse_notes
+    from cogstash.core.notes import parse_notes
     notes = parse_notes(f)
 
     assert notes[0].is_done is False
@@ -73,7 +74,7 @@ def _make_notes_file(tmp_path):
 
 def test_search_keyword(tmp_path):
     """Substring match finds correct notes."""
-    from cogstash.search import parse_notes, search_notes
+    from cogstash.core.notes import parse_notes, search_notes
     notes = parse_notes(_make_notes_file(tmp_path))
     results = search_notes(notes, "buy")
     assert len(results) == 2
@@ -81,7 +82,7 @@ def test_search_keyword(tmp_path):
 
 def test_search_case_insensitive(tmp_path):
     """Search is case-insensitive."""
-    from cogstash.search import parse_notes, search_notes
+    from cogstash.core.notes import parse_notes, search_notes
     notes = parse_notes(_make_notes_file(tmp_path))
     results = search_notes(notes, "MILK")
     assert len(results) == 1
@@ -90,7 +91,7 @@ def test_search_case_insensitive(tmp_path):
 
 def test_search_multi_word(tmp_path):
     """Multiple words are AND'd."""
-    from cogstash.search import parse_notes, search_notes
+    from cogstash.core.notes import parse_notes, search_notes
     notes = parse_notes(_make_notes_file(tmp_path))
     results = search_notes(notes, "buy eggs")
     assert len(results) == 1
@@ -99,7 +100,7 @@ def test_search_multi_word(tmp_path):
 
 def test_filter_by_tag(tmp_path):
     """Filters to only notes with given tag."""
-    from cogstash.search import filter_by_tag, parse_notes
+    from cogstash.core.notes import filter_by_tag, parse_notes
     notes = parse_notes(_make_notes_file(tmp_path))
     results = filter_by_tag(notes, "todo")
     assert len(results) == 2
@@ -111,7 +112,7 @@ def test_mark_done(tmp_path):
     f = tmp_path / "cogstash.md"
     f.write_text("- [2026-03-26 14:30] ☐ buy milk #todo\n", encoding="utf-8")
 
-    from cogstash.search import mark_done, parse_notes
+    from cogstash.core.notes import mark_done, parse_notes
     notes = parse_notes(f)
     result = mark_done(f, notes[0])
 
@@ -129,7 +130,7 @@ def test_note_line_span_single(tmp_path):
         "- [2026-03-26 15:00] meeting\n",
         encoding="utf-8",
     )
-    from cogstash.search import _note_line_span, parse_notes
+    from cogstash.core.notes import _note_line_span, parse_notes
     notes = parse_notes(f)
     lines = f.read_text(encoding="utf-8").splitlines(keepends=True)
     start, end = _note_line_span(lines, notes[0].line_number)
@@ -146,7 +147,7 @@ def test_note_line_span_multiline(tmp_path):
         "- [2026-03-26 15:00] next note\n",
         encoding="utf-8",
     )
-    from cogstash.search import _note_line_span, parse_notes
+    from cogstash.core.notes import _note_line_span, parse_notes
     notes = parse_notes(f)
     lines = f.read_text(encoding="utf-8").splitlines(keepends=True)
     start, end = _note_line_span(lines, notes[0].line_number)
@@ -162,7 +163,7 @@ def test_edit_note_multiline(tmp_path):
         "- [2026-03-26 15:00] keep this\n",
         encoding="utf-8",
     )
-    from cogstash.search import edit_note, parse_notes
+    from cogstash.core.notes import edit_note, parse_notes
     notes = parse_notes(f)
     result = edit_note(f, notes[0], "new first\nnew second\nnew third")
     assert result is True
@@ -178,7 +179,7 @@ def test_edit_note_empty_rejected(tmp_path):
     """Empty new text returns False, file unchanged."""
     f = tmp_path / "cogstash.md"
     f.write_text("- [2026-03-26 14:30] original\n", encoding="utf-8")
-    from cogstash.search import edit_note, parse_notes
+    from cogstash.core.notes import edit_note, parse_notes
     notes = parse_notes(f)
     result = edit_note(f, notes[0], "   ")
     assert result is False
@@ -194,7 +195,7 @@ def test_delete_note(tmp_path):
         "- [2026-03-26 15:00] keep me\n",
         encoding="utf-8",
     )
-    from cogstash.search import delete_note, parse_notes
+    from cogstash.core.notes import delete_note, parse_notes
     notes = parse_notes(f)
     result = delete_note(f, notes[0])
     assert result is True
@@ -214,7 +215,7 @@ def test_mark_done_stale_line_number_rejected(tmp_path):
         encoding="utf-8",
     )
 
-    from cogstash.search import mark_done, parse_notes
+    from cogstash.core.notes import mark_done, parse_notes
 
     note = parse_notes(f)[1]
     f.write_text(
@@ -240,7 +241,7 @@ def test_edit_note_stale_line_number_rejected(tmp_path):
         encoding="utf-8",
     )
 
-    from cogstash.search import edit_note, parse_notes
+    from cogstash.core.notes import edit_note, parse_notes
 
     note = parse_notes(f)[1]
     current = (
@@ -263,7 +264,7 @@ def test_delete_note_stale_line_number_rejected(tmp_path):
         encoding="utf-8",
     )
 
-    from cogstash.search import delete_note, parse_notes
+    from cogstash.core.notes import delete_note, parse_notes
 
     note = parse_notes(f)[1]
     current = (
@@ -277,7 +278,7 @@ def test_delete_note_stale_line_number_rejected(tmp_path):
 
 
 def test_compute_stats_current_streak_reuses_date_set(tmp_path, monkeypatch):
-    from cogstash.search import compute_stats, parse_notes
+    from cogstash.core.notes import compute_stats, parse_notes
 
     f = tmp_path / "cogstash.md"
     f.write_text(
@@ -304,6 +305,14 @@ def test_compute_stats_current_streak_reuses_date_set(tmp_path, monkeypatch):
     assert set_calls == 1
 
 
+def test_ui_browse_imports_notes_from_core():
+    browse_source = Path("src/cogstash/ui/browse.py").read_text(encoding="utf-8")
+
+    assert "from cogstash.search import" not in browse_source
+    assert "from cogstash.core import (" in browse_source
+    assert "from cogstash.core.notes import _atomic_write" in browse_source
+
+
 def test_search_reexports_core_helpers():
     import cogstash.core.notes as core_notes
     import cogstash.search as search_mod
@@ -325,3 +334,17 @@ def test_search_reexports_private_helpers():
 
     assert search_mod._atomic_write is core_notes._atomic_write
     assert search_mod._note_line_span is core_notes._note_line_span
+
+
+def test_root_wrappers_identify_as_compatibility_shims():
+    wrapper_paths = [
+        Path("src/cogstash/app.py"),
+        Path("src/cogstash/browse.py"),
+        Path("src/cogstash/settings.py"),
+        Path("src/cogstash/search.py"),
+        Path("src/cogstash/_windows.py"),
+    ]
+
+    for wrapper_path in wrapper_paths:
+        source = wrapper_path.read_text(encoding="utf-8").lower()
+        assert "compatibility shim" in source

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -6,15 +6,28 @@ import importlib.util
 import re
 import runpy
 import sys
+import uuid
 from pathlib import Path
 
 
+def _scripts_dir() -> Path:
+    return Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _ensure_scripts_dir_on_path() -> None:
+    scripts_dir = str(_scripts_dir())
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
+
 def _load_artifacts_module():
-    repo_root = Path(__file__).resolve().parents[1]
-    module_path = repo_root / "scripts" / "_artifacts.py"
-    spec = importlib.util.spec_from_file_location("artifacts_contract", module_path)
+    _ensure_scripts_dir_on_path()
+    module_path = _scripts_dir() / "_artifacts.py"
+    spec = importlib.util.spec_from_file_location("_artifacts", module_path)
     assert spec is not None
     assert spec.loader is not None
+    if spec.name in sys.modules:
+        return sys.modules[spec.name]
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
@@ -22,8 +35,8 @@ def _load_artifacts_module():
 
 
 def _load_build_installer_module():
-    repo_root = Path(__file__).resolve().parents[1]
-    module_path = repo_root / "scripts" / "build_installer.py"
+    _ensure_scripts_dir_on_path()
+    module_path = _scripts_dir() / "build_installer.py"
     spec = importlib.util.spec_from_file_location("build_installer", module_path)
     assert spec is not None
     assert spec.loader is not None
@@ -33,8 +46,8 @@ def _load_build_installer_module():
 
 
 def _load_build_module():
-    repo_root = Path(__file__).resolve().parents[1]
-    module_path = repo_root / "scripts" / "build.py"
+    _ensure_scripts_dir_on_path()
+    module_path = _scripts_dir() / "build.py"
     spec = importlib.util.spec_from_file_location("build_script", module_path)
     assert spec is not None
     assert spec.loader is not None
@@ -92,6 +105,23 @@ def test_artifact_contract_staged_names():
     assert module.get_staged_app_dirname() == "CogStash"
     assert module.get_staged_ui_exe_name() == "CogStash.exe"
     assert module.get_staged_cli_exe_name() == "CogStash-CLI.exe"
+
+
+def test_build_script_consumes_shared_artifact_contract():
+    module = _load_build_module()
+
+    assert module.get_executable_name.__module__ == "_artifacts"
+    assert module.get_executable_name(target="ui", bundle_mode="onefile", version="1.2.3") == "CogStash-1.2.3"
+    assert module.get_executable_name(target="cli", bundle_mode="onefile", version="1.2.3") == "CogStash-CLI-1.2.3"
+
+
+def test_build_installer_consumes_shared_artifact_contract():
+    module = _load_build_installer_module()
+
+    assert module.windows_artifact_layout.__module__ == "_artifacts"
+    assert module.get_staged_app_dirname.__module__ == "_artifacts"
+    assert module.get_staged_ui_exe_name.__module__ == "_artifacts"
+    assert module.get_staged_cli_exe_name.__module__ == "_artifacts"
 
 
 def test_inno_setup_script_supports_optional_startup_task():
@@ -182,24 +212,26 @@ def test_installed_startup_state_contract_is_implemented_in_config_and_ui():
     assert ".cogstash-installed" in iss_content
 
 
-def test_stage_windows_payload_copies_bundle_and_renames_exe(tmp_path):
+def test_stage_windows_payload_copies_bundle_and_renames_exe():
     """Stage helper should normalize app names and include the CLI executable."""
     module = _load_build_installer_module()
     version = "1.2.3"
-    bundle_dir = tmp_path / "dist" / f"CogStash-{version}-onedir"
+    repo_root = Path(__file__).resolve().parents[1]
+    scratch_root = repo_root / ".tmp" / f"test-stage-windows-payload-{uuid.uuid4().hex}"
+    bundle_dir = scratch_root / "dist" / f"CogStash-{version}-onedir"
     bundle_dir.mkdir(parents=True)
     (bundle_dir / f"CogStash-{version}-onedir.exe").write_text("exe", encoding="utf-8")
     (bundle_dir / "support.dll").write_text("dll", encoding="utf-8")
     (bundle_dir / "assets").mkdir()
     (bundle_dir / "assets" / "icon.png").write_text("png", encoding="utf-8")
-    cli_binary = tmp_path / "dist" / f"CogStash-CLI-{version}.exe"
+    cli_binary = scratch_root / "dist" / f"CogStash-CLI-{version}.exe"
     cli_binary.write_text("cli", encoding="utf-8")
 
     staged_dir = module.stage_windows_payload(
         bundle_dir=bundle_dir,
         cli_binary=cli_binary,
         version=version,
-        staging_root=tmp_path / "build" / "installer",
+        staging_root=scratch_root / "build" / "installer",
     )
 
     assert staged_dir.name == "CogStash"
@@ -210,7 +242,7 @@ def test_stage_windows_payload_copies_bundle_and_renames_exe(tmp_path):
     assert (staged_dir / "assets" / "icon.png").read_text(encoding="utf-8") == "png"
 
 
-def test_compile_installer_invokes_iscc_with_expected_defines(monkeypatch, tmp_path):
+def test_compile_installer_invokes_iscc_with_expected_defines(monkeypatch):
     """ISCC should receive version, source, and output defines."""
     module = _load_build_installer_module()
     calls = []
@@ -220,9 +252,13 @@ def test_compile_installer_invokes_iscc_with_expected_defines(monkeypatch, tmp_p
 
     monkeypatch.setattr(module.subprocess, "run", fake_run)
 
-    iss_path = tmp_path / "CogStash.iss"
-    source_dir = tmp_path / "payload"
-    output_dir = tmp_path / "dist"
+    repo_root = Path(__file__).resolve().parents[1]
+    scratch_root = repo_root / ".tmp" / f"test-compile-installer-{uuid.uuid4().hex}"
+    scratch_root.mkdir(parents=True)
+    iss_path = scratch_root / "CogStash.iss"
+    iss_path.write_text("; mock", encoding="utf-8")
+    source_dir = scratch_root / "payload"
+    output_dir = scratch_root / "dist"
 
     module.compile_installer(
         compiler="iscc.exe",

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -9,6 +9,18 @@ import sys
 from pathlib import Path
 
 
+def _load_artifacts_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "scripts" / "_artifacts.py"
+    spec = importlib.util.spec_from_file_location("artifacts_contract", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def _load_build_installer_module():
     repo_root = Path(__file__).resolve().parents[1]
     module_path = repo_root / "scripts" / "build_installer.py"
@@ -42,6 +54,44 @@ def test_inno_setup_script_uses_per_user_defaults():
     assert "PrivilegesRequired=lowest" in content
     assert "OutputBaseFilename=CogStash-v{#AppVersion}-setup" in content
     assert 'Name: "{group}\\CogStash"; Filename: "{app}\\CogStash.exe"' in content
+
+
+def test_artifact_contract_build_names():
+    module = _load_artifacts_module()
+
+    assert module.get_executable_name(target="ui", bundle_mode="onefile", version="1.2.3") == "CogStash-1.2.3"
+    assert module.get_executable_name(target="ui", bundle_mode="onedir", version="1.2.3") == "CogStash-1.2.3-onedir"
+    assert module.get_executable_name(target="cli", bundle_mode="onefile", version="1.2.3") == "CogStash-CLI-1.2.3"
+
+
+def test_artifact_contract_windows_paths():
+    module = _load_artifacts_module()
+
+    dist_dir = Path("C:/tmp/dist")
+    layout = module.windows_artifact_layout(version="1.2.3", dist_dir=dist_dir)
+
+    assert layout.onedir_dir == dist_dir / "CogStash-1.2.3-onedir"
+    assert layout.onedir_exe == layout.onedir_dir / "CogStash-1.2.3-onedir.exe"
+    assert layout.cli_exe == dist_dir / "CogStash-CLI-1.2.3.exe"
+    assert layout.staged_app_dirname == "CogStash"
+    assert layout.staged_ui_exe_name == "CogStash.exe"
+    assert layout.staged_cli_exe_name == "CogStash-CLI.exe"
+
+
+def test_artifact_contract_release_archive_names():
+    module = _load_artifacts_module()
+
+    assert module.get_release_archive_name(tag="v1.2.3", platform_suffix="windows") == "CogStash-v1.2.3-windows.zip"
+    assert module.get_release_archive_name(tag="v1.2.3", platform_suffix="macos") == "CogStash-v1.2.3-macos.zip"
+    assert module.get_release_archive_name(tag="v1.2.3", platform_suffix="linux") == "CogStash-v1.2.3-linux.tar.gz"
+
+
+def test_artifact_contract_staged_names():
+    module = _load_artifacts_module()
+
+    assert module.get_staged_app_dirname() == "CogStash"
+    assert module.get_staged_ui_exe_name() == "CogStash.exe"
+    assert module.get_staged_cli_exe_name() == "CogStash-CLI.exe"
 
 
 def test_inno_setup_script_supports_optional_startup_task():

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -396,6 +396,25 @@ def test_release_workflow_builds_and_uploads_windows_installer():
     assert "--version output unexpectedly contained Traceback" in content
 
 
+def test_release_workflow_uses_shared_artifact_contract():
+    repo_root = Path(__file__).resolve().parents[1]
+    workflow_path = repo_root / ".github" / "workflows" / "release.yml"
+
+    content = workflow_path.read_text(encoding="utf-8")
+
+    assert "sys.path.insert(0, \"scripts\")" in content
+    assert "from _artifacts import get_executable_name" in content
+    assert "from _artifacts import get_release_archive_name" in content
+    assert "get_executable_name(target='ui', bundle_mode='onefile'" in content
+    assert "get_executable_name(target='cli', bundle_mode='onefile'" in content
+    assert "get_release_archive_name(tag=\"${{ github.ref_name }}\", platform_suffix=\"windows\")" in content
+    assert "get_release_archive_name(tag=\"${{ github.ref_name }}\", platform_suffix=\"macos\")" in content
+    assert "get_release_archive_name(tag=\"${{ github.ref_name }}\", platform_suffix=\"linux\")" in content
+    assert "CogStash-${{ github.ref_name }}-windows.zip" not in content
+    assert "CogStash-${{ github.ref_name }}-macos.zip" not in content
+    assert "CogStash-${{ github.ref_name }}-linux.tar.gz" not in content
+
+
 def test_release_workflow_uploads_ui_and_cli_artifacts():
     repo_root = Path(__file__).resolve().parents[1]
     workflow_path = repo_root / ".github" / "workflows" / "release.yml"

--- a/tests/ui/test_app.py
+++ b/tests/ui/test_app.py
@@ -583,3 +583,71 @@ def test_app_main_installer_welcome_shown_for_first_installed_launch(monkeypatch
 
     assert len(welcome_calls) == 1
     assert saved_configs == [cogstash.__version__]
+
+
+def test_app_main_delegates_dpi_setup_to_windows_runtime(monkeypatch, tmp_path):
+    import types
+
+    import cogstash
+    import cogstash.ui.app as app_mod
+    import cogstash.ui.windows_runtime as runtime_mod
+
+    calls: list[str] = []
+
+    class FakeRoot:
+        def mainloop(self):
+            return None
+
+    class FakeApp:
+        def __init__(self, _root, _config):
+            self.queue = object()
+
+    class FakeGuard:
+        def close(self):
+            return None
+
+    class FakeListener:
+        def __init__(self, _mapping):
+            pass
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    config = app_mod.CogStashConfig(
+        output_file=tmp_path / "notes.md",
+        log_file=tmp_path / "cogstash.log",
+        last_seen_version=cogstash.__version__,
+        last_seen_installer_version=cogstash.__version__,
+    )
+    windows_mod = types.ModuleType("cogstash.ui.windows")
+    windows_mod.WINDOWS_MUTEX_NAME = "Local\\CogStash.Test"
+    windows_mod.acquire_single_instance = lambda _name: FakeGuard()
+
+    monkeypatch.setattr(app_mod, "load_config", lambda _path: config)
+    monkeypatch.setattr(runtime_mod, "configure_dpi", lambda: calls.append("dpi"))
+    monkeypatch.setattr(app_mod.tk, "Tk", lambda: FakeRoot())
+    monkeypatch.setattr(app_mod, "CogStash", FakeApp)
+    monkeypatch.setattr(app_mod, "create_tray_icon", lambda _queue, _config: None)
+    monkeypatch.setattr(app_mod.keyboard, "GlobalHotKeys", FakeListener)
+    monkeypatch.setattr(app_mod.messagebox, "showinfo", lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(sys.modules, "cogstash.ui.windows", windows_mod)
+    monkeypatch.setattr("sys.stdout", StrictEncodedStream("cp1252"))
+
+    original_handlers = app_mod.logger.handlers[:]
+    try:
+        app_mod.main()
+    finally:
+        for handler in [h for h in app_mod.logger.handlers[:] if h not in original_handlers]:
+            app_mod.logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+        for handler in original_handlers:
+            if handler not in app_mod.logger.handlers:
+                app_mod.logger.addHandler(handler)
+
+    assert calls == ["dpi"]

--- a/tests/ui/test_app.py
+++ b/tests/ui/test_app.py
@@ -12,6 +12,18 @@ from _helpers import StrictEncodedStream
 from ui._support import needs_display
 
 
+def _patch_runtime_startup(monkeypatch, app_mod, *, start_runtime=None, start_hotkey_listener=None, shutdown_runtime=None):
+    handles = app_mod.app_runtime.AppRuntimeHandles()
+    monkeypatch.setattr(app_mod.app_runtime, "start_runtime", start_runtime or (lambda *_a, **_k: handles))
+    monkeypatch.setattr(
+        app_mod.app_runtime,
+        "start_hotkey_listener",
+        start_hotkey_listener or (lambda *_a, **_k: object()),
+    )
+    monkeypatch.setattr(app_mod.app_runtime, "shutdown_runtime", shutdown_runtime or (lambda _handles: None))
+    return handles
+
+
 def _run_main_startup(monkeypatch, tmp_path, listener_cls):
     import types
 
@@ -53,8 +65,15 @@ def _run_main_startup(monkeypatch, tmp_path, listener_cls):
     monkeypatch.setattr(app_mod, "configure_dpi", lambda: None)
     monkeypatch.setattr(app_mod.tk, "Tk", lambda: FakeRoot())
     monkeypatch.setattr(app_mod, "CogStash", FakeApp)
-    monkeypatch.setattr(app_mod, "create_tray_icon", lambda _queue, _config: None)
-    monkeypatch.setattr(app_mod.keyboard, "GlobalHotKeys", listener_cls)
+    if listener_cls is None:
+        def start_hotkey_listener(*_a, **_k):
+            raise AssertionError("hotkey listener should not be started")
+    else:
+        def start_hotkey_listener(_queue, hotkey):
+            listener = listener_cls({hotkey: lambda: None})
+            listener.start()
+            return listener
+    _patch_runtime_startup(monkeypatch, app_mod, start_hotkey_listener=start_hotkey_listener)
     monkeypatch.setattr(app_mod.messagebox, "showwarning", lambda *a, **kw: warnings.append((a, kw)))
     monkeypatch.setattr(
         app_mod.messagebox,
@@ -142,8 +161,11 @@ def test_app_main_startup_output_is_cp1252_safe(monkeypatch, tmp_path):
     monkeypatch.setattr(app_mod, "configure_dpi", lambda: None)
     monkeypatch.setattr(app_mod.tk, "Tk", lambda: FakeRoot())
     monkeypatch.setattr(app_mod, "CogStash", FakeApp)
-    monkeypatch.setattr(app_mod, "create_tray_icon", lambda _queue, _config: None)
-    monkeypatch.setattr(app_mod.keyboard, "GlobalHotKeys", FakeListener)
+    _patch_runtime_startup(
+        monkeypatch,
+        app_mod,
+        start_hotkey_listener=lambda _queue, hotkey: FakeListener({hotkey: lambda: None}),
+    )
     monkeypatch.setattr(
         app_mod.messagebox,
         "showinfo",
@@ -293,8 +315,11 @@ def test_app_open_settings_receives_runtime_hotkey_warning_after_startup_failure
     monkeypatch.setattr(app_mod.tk, "Tk", lambda: tk_root)
     monkeypatch.setattr(tk_root, "mainloop", lambda: None)
     monkeypatch.setattr(app_mod, "CogStash", capture_app)
-    monkeypatch.setattr(app_mod, "create_tray_icon", lambda _queue, _config: None)
-    monkeypatch.setattr(app_mod.keyboard, "GlobalHotKeys", FailingListener)
+    _patch_runtime_startup(
+        monkeypatch,
+        app_mod,
+        start_hotkey_listener=lambda *_a, **_k: (_ for _ in ()).throw(OSError("hotkey already in use")),
+    )
     monkeypatch.setattr(app_mod.messagebox, "showwarning", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         app_mod.messagebox,
@@ -487,8 +512,11 @@ def test_app_main_installer_welcome_shown_for_installed_upgrade(monkeypatch, tmp
     monkeypatch.setattr(app_mod, "configure_dpi", lambda: None)
     monkeypatch.setattr(app_mod.tk, "Tk", lambda: FakeRoot())
     monkeypatch.setattr(app_mod, "CogStash", FakeApp)
-    monkeypatch.setattr(app_mod, "create_tray_icon", lambda _queue, _config: None)
-    monkeypatch.setattr(app_mod.keyboard, "GlobalHotKeys", FakeListener)
+    _patch_runtime_startup(
+        monkeypatch,
+        app_mod,
+        start_hotkey_listener=lambda _queue, hotkey: FakeListener({hotkey: lambda: None}),
+    )
     monkeypatch.setattr(app_mod, "save_config", lambda _c, _p: None)
     monkeypatch.setattr(install_state_mod, "is_installed_windows_run", lambda: True)
     monkeypatch.setattr(settings_mod, "InstallerWelcomeDialog", lambda *a, **kw: welcome_calls.append(a), raising=False)
@@ -560,8 +588,11 @@ def test_app_main_installer_welcome_shown_for_first_installed_launch(monkeypatch
     monkeypatch.setattr(app_mod, "configure_dpi", lambda: None)
     monkeypatch.setattr(app_mod.tk, "Tk", lambda: FakeRoot())
     monkeypatch.setattr(app_mod, "CogStash", FakeApp)
-    monkeypatch.setattr(app_mod, "create_tray_icon", lambda _queue, _config: None)
-    monkeypatch.setattr(app_mod.keyboard, "GlobalHotKeys", FakeListener)
+    _patch_runtime_startup(
+        monkeypatch,
+        app_mod,
+        start_hotkey_listener=lambda _queue, hotkey: FakeListener({hotkey: lambda: None}),
+    )
     monkeypatch.setattr(app_mod, "save_config", lambda c, _p: saved_configs.append(c.last_seen_installer_version))
     monkeypatch.setattr(install_state_mod, "is_installed_windows_run", lambda: True)
     monkeypatch.setattr(settings_mod, "InstallerWelcomeDialog", lambda *a, **kw: welcome_calls.append(a), raising=False)
@@ -630,8 +661,11 @@ def test_app_main_delegates_dpi_setup_to_windows_runtime(monkeypatch, tmp_path):
     monkeypatch.setattr(runtime_mod, "configure_dpi", lambda: calls.append("dpi"))
     monkeypatch.setattr(app_mod.tk, "Tk", lambda: FakeRoot())
     monkeypatch.setattr(app_mod, "CogStash", FakeApp)
-    monkeypatch.setattr(app_mod, "create_tray_icon", lambda _queue, _config: None)
-    monkeypatch.setattr(app_mod.keyboard, "GlobalHotKeys", FakeListener)
+    _patch_runtime_startup(
+        monkeypatch,
+        app_mod,
+        start_hotkey_listener=lambda _queue, hotkey: FakeListener({hotkey: lambda: None}),
+    )
     monkeypatch.setattr(app_mod.messagebox, "showinfo", lambda *_args, **_kwargs: None)
     monkeypatch.setitem(sys.modules, "cogstash.ui.windows", windows_mod)
     monkeypatch.setattr("sys.stdout", StrictEncodedStream("cp1252"))
@@ -651,3 +685,24 @@ def test_app_main_delegates_dpi_setup_to_windows_runtime(monkeypatch, tmp_path):
                 app_mod.logger.addHandler(handler)
 
     assert calls == ["dpi"]
+
+
+@needs_display
+def test_poll_queue_delegates_to_app_runtime(monkeypatch, tk_root):
+    import cogstash.ui.app as app_mod
+
+    app = app_mod.CogStash(tk_root, app_mod.CogStashConfig())
+    calls: list[object] = []
+
+    def fake_drain(app_queue, **callbacks):
+        calls.append(app_queue)
+        callbacks["on_show"]()
+        return False
+
+    monkeypatch.setattr(app_mod.app_runtime, "drain_app_queue", fake_drain)
+    monkeypatch.setattr(app, "show_window", lambda: calls.append("show"))
+
+    app.poll_queue()
+
+    assert calls[0] is app.queue
+    assert calls[1] == "show"

--- a/tests/ui/test_app_compat.py
+++ b/tests/ui/test_app_compat.py
@@ -331,8 +331,13 @@ def test_app_main_startup_output_is_cp1252_safe(monkeypatch, tmp_path):
     monkeypatch.setattr(app_mod, "configure_dpi", lambda: None)
     monkeypatch.setattr(app_mod.tk, "Tk", lambda: FakeRoot())
     monkeypatch.setattr(app_mod, "CogStash", FakeApp)
-    monkeypatch.setattr(app_mod, "create_tray_icon", lambda _queue, _config: None)
-    monkeypatch.setattr(app_mod.keyboard, "GlobalHotKeys", FakeListener)
+    monkeypatch.setattr(app_mod.app_runtime, "start_runtime", lambda *_a, **_k: app_mod.app_runtime.AppRuntimeHandles())
+    monkeypatch.setattr(
+        app_mod.app_runtime,
+        "start_hotkey_listener",
+        lambda _queue, hotkey: FakeListener({hotkey: lambda: None}),
+    )
+    monkeypatch.setattr(app_mod.app_runtime, "shutdown_runtime", lambda _handles: None)
     monkeypatch.setattr(
         app_mod.messagebox,
         "showinfo",

--- a/tests/ui/test_app_runtime.py
+++ b/tests/ui/test_app_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import queue
+from types import SimpleNamespace
 
 
 def test_drain_queue_dispatches_supported_commands():
@@ -33,6 +34,26 @@ def test_drain_queue_ignores_unknown_commands():
 
     app_queue: queue.Queue[object] = queue.Queue()
     app_queue.put("UNKNOWN")
+
+    events: list[str] = []
+
+    should_continue = runtime.drain_app_queue(
+        app_queue,
+        on_show=lambda: events.append("show"),
+        on_browse=lambda: events.append("browse"),
+        on_settings=lambda: events.append("settings"),
+        on_quit=lambda: events.append("quit"),
+    )
+
+    assert events == []
+    assert should_continue is True
+
+
+def test_drain_queue_rejects_legacy_string_commands():
+    import cogstash.ui.app_runtime as runtime
+
+    app_queue: queue.Queue[object] = queue.Queue()
+    app_queue.put("SHOW")
 
     events: list[str] = []
 
@@ -88,6 +109,84 @@ def test_register_hotkey_listener_enqueues_show_command(monkeypatch):
 
     assert listener.started is True
     assert app_queue.get_nowait() is runtime.AppCommand.SHOW
+
+
+def test_start_tray_icon_enqueues_shared_commands(monkeypatch):
+    import sys
+
+    import cogstash.ui.app_runtime as runtime
+
+    app_queue: queue.Queue[runtime.AppCommand] = queue.Queue()
+    created_items: list[SimpleNamespace] = []
+
+    class FakeMenuItem:
+        def __init__(self, label, command, enabled=True):
+            self.label = label
+            self.command = command
+            self.enabled = enabled
+
+    class FakeMenu:
+        SEPARATOR = object()
+
+        def __call__(self, *items):
+            created_items.append(SimpleNamespace(items=items))
+            return items
+
+    class FakeIcon:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            self.started = False
+            self.stopped = False
+
+        def run(self):
+            self.started = True
+
+        def stop(self):
+            self.stopped = True
+
+    fake_pystray = SimpleNamespace(Menu=FakeMenu(), MenuItem=FakeMenuItem, Icon=FakeIcon)
+    monkeypatch.setitem(sys.modules, "pystray", fake_pystray)
+    monkeypatch.setattr(runtime, "_create_tray_image", lambda _theme: object())
+
+    icon = runtime.start_tray_icon(
+        app_queue,
+        runtime.CogStashConfig(),
+        themes={"tokyo-night": {"bg": "#000000", "fg": "#ffffff"}},
+    )
+
+    menu_items = created_items[0].items
+    browse_item = menu_items[3]
+    settings_item = menu_items[4]
+    quit_item = menu_items[6]
+
+    browse_item.command()
+    assert app_queue.get_nowait() is runtime.AppCommand.BROWSE
+
+    settings_item.command()
+    assert app_queue.get_nowait() is runtime.AppCommand.SETTINGS
+
+    quit_item.command(icon)
+    assert icon.stopped is True
+    assert app_queue.get_nowait() is runtime.AppCommand.QUIT
+
+
+def test_start_runtime_returns_shutdown_safe_handles(monkeypatch):
+    import cogstash.ui.app_runtime as runtime
+
+    tray_icon = SimpleNamespace(stop=lambda: None)
+    monkeypatch.setattr(runtime, "start_tray_icon", lambda *_args, **_kwargs: tray_icon)
+
+    handles = runtime.start_runtime(
+        queue.Queue(),
+        runtime.CogStashConfig(),
+        themes={"tokyo-night": {"bg": "#000000", "fg": "#ffffff"}},
+    )
+
+    assert handles.tray_icon is tray_icon
+    assert handles.hotkey_listener is None
+
+    runtime.shutdown_runtime(handles)
 
 
 def test_shutdown_runtime_stops_listener_and_tray():

--- a/tests/ui/test_app_runtime.py
+++ b/tests/ui/test_app_runtime.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import queue
-from types import SimpleNamespace
 
 
 def test_drain_queue_dispatches_supported_commands():
@@ -69,11 +68,10 @@ def test_register_hotkey_listener_enqueues_show_command(monkeypatch):
     import cogstash.ui.app_runtime as runtime
 
     app_queue: queue.Queue[runtime.AppCommand] = queue.Queue()
-    created_mappings: list[dict[str, object]] = []
 
     class FakeListener:
         def __init__(self, mapping):
-            created_mappings.append(mapping)
+            self.mapping = dict(mapping)
             self.started = False
 
         def start(self):
@@ -83,7 +81,7 @@ def test_register_hotkey_listener_enqueues_show_command(monkeypatch):
 
     listener = runtime.start_hotkey_listener(app_queue, "<ctrl>+<alt>+space")
 
-    hotkey_callback = created_mappings[0]["<ctrl>+<alt>+space"]
+    hotkey_callback = next(iter(listener.mapping.values()))
     hotkey_callback()
 
     assert listener.started is True
@@ -95,14 +93,22 @@ def test_shutdown_runtime_stops_listener_and_tray():
 
     stopped: list[str] = []
 
+    class FakeStopHandle:
+        def __init__(self, name: str):
+            self.name = name
+
+        def stop(self):
+            stopped.append(self.name)
+
     runtime.shutdown_runtime(
         runtime.AppRuntimeHandles(
-            tray_icon=SimpleNamespace(stop=lambda: stopped.append("tray")),
-            hotkey_listener=SimpleNamespace(stop=lambda: stopped.append("hotkey")),
+            tray_icon=FakeStopHandle("tray"),
+            hotkey_listener=FakeStopHandle("hotkey"),
         )
     )
 
-    assert stopped == ["tray", "hotkey"]
+    assert set(stopped) == {"tray", "hotkey"}
+    assert len(stopped) == 2
 
 
 def test_shutdown_runtime_tolerates_missing_handles():

--- a/tests/ui/test_app_runtime.py
+++ b/tests/ui/test_app_runtime.py
@@ -68,6 +68,7 @@ def test_register_hotkey_listener_enqueues_show_command(monkeypatch):
     import cogstash.ui.app_runtime as runtime
 
     app_queue: queue.Queue[runtime.AppCommand] = queue.Queue()
+    hotkey = "<ctrl>+<alt>+space"
 
     class FakeListener:
         def __init__(self, mapping):
@@ -79,9 +80,10 @@ def test_register_hotkey_listener_enqueues_show_command(monkeypatch):
 
     monkeypatch.setattr(runtime.keyboard, "GlobalHotKeys", FakeListener)
 
-    listener = runtime.start_hotkey_listener(app_queue, "<ctrl>+<alt>+space")
+    listener = runtime.start_hotkey_listener(app_queue, hotkey)
 
-    hotkey_callback = next(iter(listener.mapping.values()))
+    assert list(listener.mapping.keys()) == [hotkey]
+    hotkey_callback = listener.mapping[hotkey]
     hotkey_callback()
 
     assert listener.started is True

--- a/tests/ui/test_app_runtime.py
+++ b/tests/ui/test_app_runtime.py
@@ -1,0 +1,111 @@
+"""Focused runtime-contract tests for cogstash.ui.app_runtime."""
+
+from __future__ import annotations
+
+import queue
+from types import SimpleNamespace
+
+
+def test_drain_queue_dispatches_supported_commands():
+    import cogstash.ui.app_runtime as runtime
+
+    app_queue: queue.Queue[runtime.AppCommand] = queue.Queue()
+    app_queue.put(runtime.AppCommand.SHOW)
+    app_queue.put(runtime.AppCommand.BROWSE)
+    app_queue.put(runtime.AppCommand.SETTINGS)
+    app_queue.put(runtime.AppCommand.QUIT)
+
+    events: list[str] = []
+
+    should_continue = runtime.drain_app_queue(
+        app_queue,
+        on_show=lambda: events.append("show"),
+        on_browse=lambda: events.append("browse"),
+        on_settings=lambda: events.append("settings"),
+        on_quit=lambda: events.append("quit"),
+    )
+
+    assert events == ["show", "browse", "settings", "quit"]
+    assert should_continue is False
+
+
+def test_drain_queue_ignores_unknown_commands():
+    import cogstash.ui.app_runtime as runtime
+
+    app_queue: queue.Queue[object] = queue.Queue()
+    app_queue.put("UNKNOWN")
+
+    events: list[str] = []
+
+    should_continue = runtime.drain_app_queue(
+        app_queue,
+        on_show=lambda: events.append("show"),
+        on_browse=lambda: events.append("browse"),
+        on_settings=lambda: events.append("settings"),
+        on_quit=lambda: events.append("quit"),
+    )
+
+    assert events == []
+    assert should_continue is True
+
+
+def test_drain_queue_handles_empty_queue():
+    import cogstash.ui.app_runtime as runtime
+
+    app_queue: queue.Queue[runtime.AppCommand] = queue.Queue()
+
+    should_continue = runtime.drain_app_queue(
+        app_queue,
+        on_show=lambda: None,
+        on_browse=lambda: None,
+        on_settings=lambda: None,
+        on_quit=lambda: None,
+    )
+
+    assert should_continue is True
+
+
+def test_register_hotkey_listener_enqueues_show_command(monkeypatch):
+    import cogstash.ui.app_runtime as runtime
+
+    app_queue: queue.Queue[runtime.AppCommand] = queue.Queue()
+    created_mappings: list[dict[str, object]] = []
+
+    class FakeListener:
+        def __init__(self, mapping):
+            created_mappings.append(mapping)
+            self.started = False
+
+        def start(self):
+            self.started = True
+
+    monkeypatch.setattr(runtime.keyboard, "GlobalHotKeys", FakeListener)
+
+    listener = runtime.start_hotkey_listener(app_queue, "<ctrl>+<alt>+space")
+
+    hotkey_callback = created_mappings[0]["<ctrl>+<alt>+space"]
+    hotkey_callback()
+
+    assert listener.started is True
+    assert app_queue.get_nowait() is runtime.AppCommand.SHOW
+
+
+def test_shutdown_runtime_stops_listener_and_tray():
+    import cogstash.ui.app_runtime as runtime
+
+    stopped: list[str] = []
+
+    runtime.shutdown_runtime(
+        runtime.AppRuntimeHandles(
+            tray_icon=SimpleNamespace(stop=lambda: stopped.append("tray")),
+            hotkey_listener=SimpleNamespace(stop=lambda: stopped.append("hotkey")),
+        )
+    )
+
+    assert stopped == ["tray", "hotkey"]
+
+
+def test_shutdown_runtime_tolerates_missing_handles():
+    import cogstash.ui.app_runtime as runtime
+
+    runtime.shutdown_runtime(runtime.AppRuntimeHandles())

--- a/tests/ui/test_app_runtime.py
+++ b/tests/ui/test_app_runtime.py
@@ -156,17 +156,19 @@ def test_start_tray_icon_enqueues_shared_commands(monkeypatch):
     )
 
     menu_items = created_items[0].items
-    browse_item = menu_items[3]
-    settings_item = menu_items[4]
-    quit_item = menu_items[6]
+    items_by_label = {
+        item.label: item
+        for item in menu_items
+        if getattr(item, "label", None)
+    }
 
-    browse_item.command()
+    items_by_label["Browse Notes"].command()
     assert app_queue.get_nowait() is runtime.AppCommand.BROWSE
 
-    settings_item.command()
+    items_by_label["Settings"].command()
     assert app_queue.get_nowait() is runtime.AppCommand.SETTINGS
 
-    quit_item.command(icon)
+    items_by_label["Quit"].command(icon)
     assert icon.stopped is True
     assert app_queue.get_nowait() is runtime.AppCommand.QUIT
 

--- a/tests/ui/test_browse_extended.py
+++ b/tests/ui/test_browse_extended.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -14,8 +15,8 @@ def test_browse_window_creates(tmp_path, tk_root):
     f = tmp_path / "cogstash.md"
     f.write_text("- [2026-03-26 14:30] ☐ test note #todo\n", encoding="utf-8")
 
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
 
     config = CogStashConfig(output_file=f)
     win = BrowseWindow(tk_root, config)
@@ -33,8 +34,8 @@ def test_browse_search_filters(tmp_path, tk_root):
         encoding="utf-8",
     )
 
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
 
     config = CogStashConfig(output_file=f)
     win = BrowseWindow(tk_root, config)
@@ -59,8 +60,8 @@ def test_browse_tag_filter(tmp_path, tk_root):
         encoding="utf-8",
     )
 
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
 
     config = CogStashConfig(output_file=f)
     win = BrowseWindow(tk_root, config)
@@ -77,8 +78,8 @@ def test_browse_tag_filter(tmp_path, tk_root):
 @needs_display
 def test_browse_custom_tag_pills(tk_root, tmp_path):
     """Custom tags appear as filter pills in the browse window."""
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
     notes_file = tmp_path / "cogstash.md"
     notes_file.write_text("- [2026-03-27 10:00] meeting #work\n", encoding="utf-8")
     config = CogStashConfig(output_file=notes_file)
@@ -95,8 +96,8 @@ def test_browse_context_menu_exists(tmp_path, tk_root):
     f = tmp_path / "cogstash.md"
     f.write_text("- [2026-03-26 14:30] test note #todo\n", encoding="utf-8")
 
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
 
     config = CogStashConfig(output_file=f)
     win = BrowseWindow(tk_root, config)
@@ -110,8 +111,8 @@ def test_browse_context_menu_releases_grab_after_popup(tmp_path, tk_root):
     f = tmp_path / "cogstash.md"
     f.write_text("- [2026-03-26 14:30] test note #todo\n", encoding="utf-8")
 
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
 
     class FakeMenu:
         last_instance = None
@@ -156,8 +157,8 @@ def test_browse_context_menu_commands_remain_callable_after_popup(tmp_path, tk_r
     f = tmp_path / "cogstash.md"
     f.write_text("- [2026-03-26 14:30] test note #todo\n", encoding="utf-8")
 
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
 
     class FakeMenu:
         last_instance = None
@@ -227,8 +228,8 @@ def test_browse_edit_note(tmp_path, tk_root):
     f = tmp_path / "cogstash.md"
     f.write_text("- [2026-03-26 14:30] original text\n", encoding="utf-8")
 
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
 
     config = CogStashConfig(output_file=f)
     win = BrowseWindow(tk_root, config)
@@ -256,8 +257,8 @@ def test_browse_edit_empty_text_shows_error(tmp_path, tk_root):
     f = tmp_path / "cogstash.md"
     f.write_text("- [2026-03-26 14:30] original text\n", encoding="utf-8")
 
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
 
     config = CogStashConfig(output_file=f)
     win = BrowseWindow(tk_root, config)
@@ -284,8 +285,8 @@ def test_browse_edit_cancel_releases_grab(tmp_path, tk_root):
     f = tmp_path / "cogstash.md"
     f.write_text("- [2026-03-26 14:30] original text\n", encoding="utf-8")
 
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
 
     config = CogStashConfig(output_file=f)
     win = BrowseWindow(tk_root, config)
@@ -316,8 +317,8 @@ def test_browse_search_enter_moves_focus_from_entry(tmp_path, tk_root):
     f = tmp_path / "cogstash.md"
     f.write_text("- [2026-03-26 14:30] test note\n", encoding="utf-8")
 
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
 
     config = CogStashConfig(output_file=f)
     win = BrowseWindow(tk_root, config)
@@ -340,8 +341,8 @@ def test_browse_delete_note(tmp_path, tk_root):
         encoding="utf-8",
     )
 
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
 
     config = CogStashConfig(output_file=f)
     win = BrowseWindow(tk_root, config)
@@ -371,8 +372,8 @@ def test_browse_delete_confirmation_uses_multiline_preview(tmp_path, tk_root):
         encoding="utf-8",
     )
 
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
 
     win = BrowseWindow(tk_root, CogStashConfig(output_file=f))
     note = win._all_notes[0]
@@ -400,8 +401,8 @@ def test_browse_delete_undo_restores_note(tmp_path, tk_root):
         encoding="utf-8",
     )
 
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
 
     win = BrowseWindow(tk_root, CogStashConfig(output_file=f))
     note = win._all_notes[0]
@@ -424,8 +425,8 @@ def test_browse_copy_shows_non_blocking_notice(tmp_path, tk_root):
     f = tmp_path / "cogstash.md"
     f.write_text("- [2026-03-26 14:30] copied text\n", encoding="utf-8")
 
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
 
     win = BrowseWindow(tk_root, CogStashConfig(output_file=f))
     note = win._all_notes[0]
@@ -444,8 +445,8 @@ def test_browse_stale_edit_reloads_and_shows_notice(tmp_path, tk_root):
     f = tmp_path / "cogstash.md"
     f.write_text("- [2026-03-26 14:30] original text\n", encoding="utf-8")
 
-    from cogstash.app import CogStashConfig
-    from cogstash.browse import BrowseWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.browse import BrowseWindow
 
     win = BrowseWindow(tk_root, CogStashConfig(output_file=f))
     note = win._all_notes[0]
@@ -466,3 +467,9 @@ def test_browse_stale_edit_reloads_and_shows_notice(tmp_path, tk_root):
     notice_mock.assert_called_once()
     error_mock.assert_not_called()
     win.window.destroy()
+
+
+def test_browse_module_avoids_search_wrapper_imports():
+    browse_source = Path("src/cogstash/ui/browse.py").read_text(encoding="utf-8")
+
+    assert "from cogstash.search import" not in browse_source

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -270,3 +270,38 @@ def test_installer_welcome_dialog_does_not_claim_path_is_changeable_in_settings(
     assert not any("Startup and PATH settings can be changed in Settings" in text for text in labels)
 
     dialog.win.destroy()
+
+
+@needs_display
+def test_settings_save_general_delegates_startup_toggle_to_windows_runtime(tk_root, tmp_path, monkeypatch):
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
+
+    calls: list[bool] = []
+    config = CogStashConfig(launch_at_startup=False)
+    config_path = tmp_path / "test.json"
+    sw = SettingsWindow(tk_root, config, config_path)
+    sw.launch_var.set(True)
+
+    monkeypatch.setattr("cogstash.ui.windows_runtime.set_launch_at_startup", lambda enabled: calls.append(enabled))
+
+    sw._save_general()
+
+    assert calls == [True]
+    sw.win.destroy()
+
+
+@needs_display
+def test_settings_open_link_delegates_to_windows_runtime(tk_root, tmp_path, monkeypatch):
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
+
+    calls: list[str] = []
+    sw = SettingsWindow(tk_root, CogStashConfig(), tmp_path / "test.json")
+
+    monkeypatch.setattr("cogstash.ui.windows_runtime.open_target_in_shell", lambda target: calls.append(target))
+
+    sw._open_link("https://example.com")
+
+    assert calls == ["https://example.com"]
+    sw.win.destroy()

--- a/tests/ui/test_settings_extended.py
+++ b/tests/ui/test_settings_extended.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -13,7 +14,8 @@ from ui._support import needs_display
 @needs_display
 def test_settings_queue_message(tk_root):
     """SETTINGS message in queue triggers _open_settings."""
-    from cogstash.app import CogStash, CogStashConfig
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.app import CogStash
 
     config = CogStashConfig()
     app = CogStash(tk_root, config)
@@ -27,8 +29,8 @@ def test_settings_queue_message(tk_root):
 @needs_display
 def test_settings_window_has_tabs(tk_root, tmp_path):
     """Settings window creates 4 tabs."""
-    from cogstash.app import CogStashConfig
-    from cogstash.settings import SettingsWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
     config = CogStashConfig()
     sw = SettingsWindow(tk_root, config, tmp_path / "test.json")
     assert hasattr(sw, "tab_buttons")
@@ -39,8 +41,8 @@ def test_settings_window_has_tabs(tk_root, tmp_path):
 @needs_display
 def test_settings_window_not_transient_to_withdrawn_root(tk_root, tmp_path):
     """Settings window should not be transient to the hidden app root."""
-    from cogstash.app import CogStashConfig
-    from cogstash.settings import SettingsWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
 
     config = CogStashConfig()
     sw = SettingsWindow(tk_root, config, tmp_path / "test.json")
@@ -51,8 +53,8 @@ def test_settings_window_not_transient_to_withdrawn_root(tk_root, tmp_path):
 @needs_display
 def test_settings_general_tab_widgets(tk_root, tmp_path):
     """General tab has hotkey label, notes file entry, and launch checkbox."""
-    from cogstash.app import CogStashConfig
-    from cogstash.settings import SettingsWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
     config = CogStashConfig()
     sw = SettingsWindow(tk_root, config, tmp_path / "test.json")
     assert hasattr(sw, "notes_file_var")
@@ -63,8 +65,8 @@ def test_settings_general_tab_widgets(tk_root, tmp_path):
 @needs_display
 def test_settings_escape_closes_window(tk_root, tmp_path):
     """Escape closes the settings window."""
-    from cogstash.app import CogStashConfig
-    from cogstash.settings import SettingsWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
 
     sw = SettingsWindow(tk_root, CogStashConfig(), tmp_path / "test.json")
     sw.win.focus_force()
@@ -77,8 +79,8 @@ def test_settings_escape_closes_window(tk_root, tmp_path):
 @needs_display
 def test_settings_appearance_tab(tk_root, tmp_path):
     """Appearance tab has theme swatches and window size options."""
-    from cogstash.app import CogStashConfig
-    from cogstash.settings import SettingsWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
     config = CogStashConfig()
     sw = SettingsWindow(tk_root, config, tmp_path / "test.json")
     assert hasattr(sw, "selected_theme")
@@ -91,8 +93,8 @@ def test_settings_appearance_tab(tk_root, tmp_path):
 @needs_display
 def test_settings_save_appearance_applies_changes_immediately(tk_root, tmp_path):
     """Appearance save should notify the app so open windows restyle immediately."""
-    from cogstash.app import CogStashConfig
-    from cogstash.settings import SettingsWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
 
     calls = []
     sw = SettingsWindow(
@@ -113,8 +115,8 @@ def test_settings_save_appearance_applies_changes_immediately(tk_root, tmp_path)
 @needs_display
 def test_settings_tags_tab(tk_root, tmp_path):
     """Tags tab shows built-in tags."""
-    from cogstash.app import CogStashConfig
-    from cogstash.settings import SettingsWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
     config = CogStashConfig()
     sw = SettingsWindow(tk_root, config, tmp_path / "test.json")
     sw._show_tab(2)
@@ -125,8 +127,8 @@ def test_settings_tags_tab(tk_root, tmp_path):
 @needs_display
 def test_settings_about_tab(tk_root, tmp_path):
     """About tab shows version info."""
-    from cogstash.app import CogStashConfig
-    from cogstash.settings import SettingsWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
     config = CogStashConfig()
     sw = SettingsWindow(tk_root, config, tmp_path / "test.json")
     sw._show_tab(3)
@@ -136,7 +138,7 @@ def test_settings_about_tab(tk_root, tmp_path):
 
 def test_first_run_detection():
     """last_seen_version=='' means first run."""
-    from cogstash.app import CogStashConfig
+    from cogstash.core import CogStashConfig
     config = CogStashConfig()
     assert config.last_seen_version == ""
     config2 = CogStashConfig(last_seen_version="0.1.0")
@@ -148,8 +150,8 @@ def test_wizard_saves_config(tk_root, tmp_path):
     """Wizard writes valid config with all fields when completed."""
     import json
 
-    from cogstash.app import CogStashConfig
-    from cogstash.settings import WizardWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.settings import WizardWindow
 
     config = CogStashConfig()
     config_path = tmp_path / ".cogstash.json"
@@ -166,8 +168,8 @@ def test_wizard_saves_config(tk_root, tmp_path):
 @needs_display
 def test_wizard_close_releases_modal_window(tk_root, tmp_path):
     """Wizard close handler destroys the modal window cleanly."""
-    from cogstash.app import CogStashConfig
-    from cogstash.settings import WizardWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.settings import WizardWindow
 
     config = CogStashConfig()
     wiz = WizardWindow(tk_root, config, tmp_path / ".cogstash.json")
@@ -178,8 +180,8 @@ def test_wizard_close_releases_modal_window(tk_root, tmp_path):
 @needs_display
 def test_wizard_escape_closes_window(tk_root, tmp_path):
     """Escape closes the wizard."""
-    from cogstash.app import CogStashConfig
-    from cogstash.settings import WizardWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.settings import WizardWindow
 
     wiz = WizardWindow(tk_root, CogStashConfig(), tmp_path / ".cogstash.json")
     wiz._close()
@@ -189,7 +191,7 @@ def test_wizard_escape_closes_window(tk_root, tmp_path):
 def test_whats_new_detection():
     """Version mismatch triggers What's New (but not on first run)."""
     from cogstash import __version__
-    from cogstash.app import CogStashConfig
+    from cogstash.core import CogStashConfig
     config_new = CogStashConfig(last_seen_version="")
     assert config_new.last_seen_version == ""
     config_old = CogStashConfig(last_seen_version="0.0.1")
@@ -202,8 +204,8 @@ def test_whats_new_detection():
 def test_whats_new_dialog_creates(tk_root, tmp_path):
     """WhatsNewDialog opens without error."""
     from cogstash import __version__
-    from cogstash.app import CogStashConfig
-    from cogstash.settings import WhatsNewDialog
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.settings import WhatsNewDialog
     config = CogStashConfig(last_seen_version="0.0.1")
     dialog = WhatsNewDialog(tk_root, config, tmp_path / ".cogstash.json", __version__)
     assert dialog.win.winfo_exists()
@@ -214,8 +216,8 @@ def test_whats_new_dialog_creates(tk_root, tmp_path):
 def test_whats_new_escape_closes_dialog(tk_root, tmp_path):
     """Escape closes the What's New dialog."""
     from cogstash import __version__
-    from cogstash.app import CogStashConfig
-    from cogstash.settings import WhatsNewDialog
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.settings import WhatsNewDialog
 
     dialog = WhatsNewDialog(tk_root, CogStashConfig(last_seen_version="0.0.1"), tmp_path / ".cogstash.json", __version__)
     dialog.win.destroy()
@@ -225,8 +227,8 @@ def test_whats_new_escape_closes_dialog(tk_root, tmp_path):
 @needs_display
 def test_settings_add_tag_submit_with_enter(tk_root, tmp_path):
     """Pressing Enter in the add-tag form submits the new tag."""
-    from cogstash.app import CogStashConfig
-    from cogstash.settings import SettingsWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
 
     sw = SettingsWindow(tk_root, CogStashConfig(), tmp_path / "test.json")
     sw._show_tab(2)
@@ -247,8 +249,8 @@ def test_settings_add_tag_submit_with_enter(tk_root, tmp_path):
 @needs_display
 def test_settings_add_tag_invalid_input_shows_error(tk_root, tmp_path):
     """Invalid custom tag input shows a validation message."""
-    from cogstash.app import CogStashConfig
-    from cogstash.settings import SettingsWindow
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
 
     sw = SettingsWindow(tk_root, CogStashConfig(), tmp_path / "test.json")
     sw._show_tab(2)
@@ -269,7 +271,7 @@ def test_settings_add_tag_invalid_input_shows_error(tk_root, tmp_path):
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
 def test_startup_shortcut_path():
     """get_startup_shortcut_path returns valid Windows startup path."""
-    from cogstash.settings import get_startup_shortcut_path
+    from cogstash.ui.install_state import get_startup_shortcut_path
     path = get_startup_shortcut_path()
     assert "Startup" in str(path) or "startup" in str(path)
     assert str(path).endswith(".bat")
@@ -278,7 +280,8 @@ def test_startup_shortcut_path():
 @needs_display
 def test_app_open_settings_uses_shared_config_path(tk_root, tmp_path):
     """App should reuse its stored config path when opening Settings."""
-    from cogstash.app import CogStash, CogStashConfig
+    from cogstash.core import CogStashConfig
+    from cogstash.ui.app import CogStash
 
     config_path = tmp_path / ".cogstash.json"
     app = CogStash(tk_root, CogStashConfig(), config_path=config_path)
@@ -295,3 +298,19 @@ def test_app_open_settings_uses_shared_config_path(tk_root, tmp_path):
 
     assert created[0][2] == config_path
     assert created[0][4] is None
+
+
+def test_settings_module_imports_core_owned_config_helpers():
+    settings_source = Path("src/cogstash/ui/settings.py").read_text(encoding="utf-8")
+    _, ui_app_import_block = settings_source.split("from cogstash.ui.app import (", 1)
+    ui_app_import_block = ui_app_import_block.split(")", 1)[0]
+
+    assert "from cogstash.core import " in settings_source
+    assert "DEFAULT_SMART_TAGS" in settings_source
+    assert "CogStashConfig" in settings_source
+    assert "merge_tags" in settings_source
+    assert "save_config" in settings_source
+    assert "DEFAULT_SMART_TAGS" not in ui_app_import_block
+    assert "CogStashConfig" not in ui_app_import_block
+    assert "merge_tags" not in ui_app_import_block
+    assert "save_config" not in ui_app_import_block

--- a/tests/ui/test_settings_extended.py
+++ b/tests/ui/test_settings_extended.py
@@ -16,10 +16,11 @@ def test_settings_queue_message(tk_root):
     """SETTINGS message in queue triggers _open_settings."""
     from cogstash.core import CogStashConfig
     from cogstash.ui.app import CogStash
+    from cogstash.ui.app_runtime import AppCommand
 
     config = CogStashConfig()
     app = CogStash(tk_root, config)
-    app.queue.put("SETTINGS")
+    app.queue.put(AppCommand.SETTINGS)
     opened = []
     app._open_settings = lambda: opened.append(True)
     app.poll_queue()


### PR DESCRIPTION
## Summary
- tighten post-split architecture boundaries across wrappers/imports, Windows runtime ownership, and UI lifecycle contracts
- add a shared packaging artifact contract and refactor build, installer, and release naming flows to consume it
- add and update focused tests plus architecture docs/specs/plans for issues #21, #22, #23, #24, and #25

## Test Plan
- [x] `python -m ruff check src/cogstash/ui/app.py src/cogstash/ui/app_runtime.py tests/ui/test_app.py tests/ui/test_app_runtime.py tests/ui/test_settings_extended.py tests/ui/test_app_compat.py`
- [x] `python -m pytest tests/ui/test_app_runtime.py tests/ui/test_app.py tests/ui/test_settings_extended.py tests/ui/test_app_compat.py tests/cli/test_main.py tests/test_build_installer.py -q`
- [x] `python -m mypy src/cogstash/ui/app.py src/cogstash/ui/app_runtime.py`
- [x] `python -m ruff check scripts/_artifacts.py scripts/build.py scripts/build_installer.py tests/test_build_installer.py`
- [x] `python -m pytest tests/test_build_installer.py -q`
- [x] `python -m mypy scripts/_artifacts.py scripts/build.py scripts/build_installer.py`

Closes #21
Closes #22
Closes #23
Closes #24
Closes #25