### PR TITLE
fix: expose CLI command on Windows PATH

### DIFF
--- a/installer/windows/CogStash.iss
+++ b/installer/windows/CogStash.iss
@@ -82,7 +82,7 @@ procedure AddAppToUserPath();
 var
   OldPath, AppDir: String;
 begin
-  AppDir := ExpandConstant('{app}');
+  AppDir := ExpandConstant('{app}\bin');
   if not RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', OldPath) then
     OldPath := '';
   if Pos(LowerCase(AppDir + ';'), LowerCase(OldPath + ';')) = 0 then

--- a/scripts/_artifacts.py
+++ b/scripts/_artifacts.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 APP_NAME = "CogStash"
 CLI_NAME = "CogStash-CLI"
@@ -9,6 +10,8 @@ CLI_NAME = "CogStash-CLI"
 STAGED_APP_DIRNAME = APP_NAME
 STAGED_UI_EXE_NAME = f"{APP_NAME}.exe"
 STAGED_CLI_EXE_NAME = f"{CLI_NAME}.exe"
+STAGED_CLI_BIN_DIRNAME = "bin"
+STAGED_CLI_SHIM_NAME = "cogstash.cmd"
 
 
 def get_executable_name(*, target: str, bundle_mode: str, version: str) -> str:
@@ -64,12 +67,34 @@ def get_staged_cli_exe_name() -> str:
     return STAGED_CLI_EXE_NAME
 
 
+def get_staged_cli_bin_dirname() -> str:
+    """Return the PATH-facing CLI bin directory inside the installer staging directory."""
+    return STAGED_CLI_BIN_DIRNAME
+
+
+def get_windows_installer_cli_bin_dirname() -> str:
+    """Compatibility name for the staged Windows CLI bin directory."""
+    return get_staged_cli_bin_dirname()
+
+
+def get_staged_cli_shim_name() -> str:
+    """Return the PATH-facing CLI shim filename inside the installer staging directory."""
+    return STAGED_CLI_SHIM_NAME
+
+
+def get_windows_installer_cli_shim_name() -> str:
+    """Compatibility name for the staged Windows CLI shim filename."""
+    return get_staged_cli_shim_name()
+
+
 def get_windows_installer_cli_exe_name() -> str:
     """Compatibility name for the staged Windows CLI executable."""
     return get_staged_cli_exe_name()
 
 
-def get_release_archive_name(*, tag: str | None = None, ref_name: str | None = None, platform_suffix: str) -> str:
+def get_release_archive_name(
+    *, tag: Optional[str] = None, ref_name: Optional[str] = None, platform_suffix: str
+) -> str:
     """Return the release archive filename for a tag and platform."""
     release_ref = tag if tag is not None else ref_name
     if release_ref is None:
@@ -93,6 +118,8 @@ class WindowsArtifactLayout:
     staged_app_dirname: str = STAGED_APP_DIRNAME
     staged_ui_exe_name: str = STAGED_UI_EXE_NAME
     staged_cli_exe_name: str = STAGED_CLI_EXE_NAME
+    staged_cli_bin_dirname: str = STAGED_CLI_BIN_DIRNAME
+    staged_cli_shim_name: str = STAGED_CLI_SHIM_NAME
 
 
 def windows_artifact_layout(*, version: str, dist_dir: Path) -> WindowsArtifactLayout:

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -18,11 +18,15 @@ except ModuleNotFoundError:
     import _artifacts  # type: ignore[no-redef]
 
 get_staged_app_dirname = _artifacts.get_staged_app_dirname
+get_staged_cli_bin_dirname = _artifacts.get_staged_cli_bin_dirname
 get_staged_cli_exe_name = _artifacts.get_staged_cli_exe_name
+get_staged_cli_shim_name = _artifacts.get_staged_cli_shim_name
 get_staged_ui_exe_name = _artifacts.get_staged_ui_exe_name
 windows_artifact_layout = _artifacts.windows_artifact_layout
 get_staged_app_dirname.__module__ = "_artifacts"
+get_staged_cli_bin_dirname.__module__ = "_artifacts"
 get_staged_cli_exe_name.__module__ = "_artifacts"
+get_staged_cli_shim_name.__module__ = "_artifacts"
 get_staged_ui_exe_name.__module__ = "_artifacts"
 windows_artifact_layout.__module__ = "_artifacts"
 
@@ -68,6 +72,11 @@ def find_windows_cli_binary(dist_dir: Path, version: str) -> Path:
     return cli_binary
 
 
+def _cli_shim_contents() -> str:
+    """Return the batch shim used for PATH-based CLI invocation on Windows."""
+    return '@echo off\n"%~dp0..\\' + get_staged_cli_exe_name() + '" %*\n'
+
+
 def stage_windows_payload(*, bundle_dir: Path, cli_binary: Path, version: str, staging_root: Path) -> Path:
     """Copy the versioned onedir bundle into a versionless installer payload."""
     layout = windows_artifact_layout(version=version, dist_dir=bundle_dir.parent)
@@ -82,6 +91,9 @@ def stage_windows_payload(*, bundle_dir: Path, cli_binary: Path, version: str, s
     staged_exe = staged_dir / get_staged_ui_exe_name()
     versioned_exe.rename(staged_exe)
     shutil.copy2(cli_binary, staged_dir / get_staged_cli_exe_name())
+    cli_bin_dir = staged_dir / get_staged_cli_bin_dirname()
+    cli_bin_dir.mkdir()
+    (cli_bin_dir / get_staged_cli_shim_name()).write_text(_cli_shim_contents(), encoding="utf-8")
     return staged_dir
 
 

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -106,6 +106,8 @@ def test_artifact_contract_windows_paths():
     assert layout.staged_app_dirname == "CogStash"
     assert layout.staged_ui_exe_name == "CogStash.exe"
     assert layout.staged_cli_exe_name == "CogStash-CLI.exe"
+    assert layout.staged_cli_bin_dirname == "bin"
+    assert layout.staged_cli_shim_name == "cogstash.cmd"
 
 
 def test_artifact_contract_release_archive_names():
@@ -122,6 +124,8 @@ def test_artifact_contract_staged_names():
     assert module.get_staged_app_dirname() == "CogStash"
     assert module.get_staged_ui_exe_name() == "CogStash.exe"
     assert module.get_staged_cli_exe_name() == "CogStash-CLI.exe"
+    assert module.get_staged_cli_bin_dirname() == "bin"
+    assert module.get_staged_cli_shim_name() == "cogstash.cmd"
 
 
 def test_build_script_consumes_shared_artifact_contract():
@@ -139,6 +143,8 @@ def test_build_installer_consumes_shared_artifact_contract():
     assert module.get_staged_app_dirname.__module__ == "_artifacts"
     assert module.get_staged_ui_exe_name.__module__ == "_artifacts"
     assert module.get_staged_cli_exe_name.__module__ == "_artifacts"
+    assert module.get_staged_cli_bin_dirname.__module__ == "_artifacts"
+    assert module.get_staged_cli_shim_name.__module__ == "_artifacts"
 
 
 def test_inno_setup_script_supports_optional_startup_task():
@@ -164,7 +170,7 @@ def test_inno_setup_script_offers_optional_path_task_with_correct_description():
 
     assert 'Name: "addtopath"; Description: "Add CogStash CLI to PATH"' in content
     assert "ChangesEnvironment=yes" in content
-    assert "ExpandConstant('{app}')" in content
+    assert "ExpandConstant('{app}\\bin')" in content
 
 
 def test_shared_artifact_contract_defines_versioned_artifact_names():
@@ -185,6 +191,8 @@ def test_shared_artifact_contract_defines_windows_layout_names():
     assert contract.get_windows_installer_app_dirname() == "CogStash"
     assert contract.get_windows_installer_exe_name() == "CogStash.exe"
     assert contract.get_windows_installer_cli_exe_name() == "CogStash-CLI.exe"
+    assert contract.get_windows_installer_cli_bin_dirname() == "bin"
+    assert contract.get_windows_installer_cli_shim_name() == "cogstash.cmd"
 
 
 def test_shared_artifact_contract_defines_release_archive_names():
@@ -272,7 +280,7 @@ def test_installed_startup_state_contract_is_implemented_in_config_and_ui():
 
 
 def test_stage_windows_payload_copies_bundle_and_renames_exe():
-    """Stage helper should normalize app names and include the CLI executable."""
+    """Stage helper should normalize app names and expose the CLI through a PATH-facing shim."""
     module = _load_build_installer_module()
     version = "1.2.3"
     repo_root = Path(__file__).resolve().parents[1]
@@ -296,6 +304,11 @@ def test_stage_windows_payload_copies_bundle_and_renames_exe():
     assert staged_dir.name == "CogStash"
     assert (staged_dir / "CogStash.exe").read_text(encoding="utf-8") == "exe"
     assert (staged_dir / "CogStash-CLI.exe").read_text(encoding="utf-8") == "cli"
+    cli_shim = staged_dir / "bin" / "cogstash.cmd"
+    assert cli_shim.is_file()
+    shim_contents = cli_shim.read_text(encoding="utf-8")
+    assert "@echo off" in shim_contents
+    assert '"%~dp0..\\CogStash-CLI.exe" %*' in shim_contents
     assert not (staged_dir / f"CogStash-{version}-onedir.exe").exists()
     assert (staged_dir / "support.dll").read_text(encoding="utf-8") == "dll"
     assert (staged_dir / "assets" / "icon.png").read_text(encoding="utf-8") == "png"
@@ -537,6 +550,7 @@ def test_installer_script_installs_cli_binary_without_shortcut():
 
     iss = iss_path.read_text(encoding="utf-8")
     assert "CogStash-CLI.exe" in iss
+    assert "{app}\\bin" in iss
     # No Start Menu or Desktop shortcut entries for CogStash CLI
     assert 'Name: "{group}\\CogStash CLI"' not in iss
     assert 'Name: "{autodesktop}\\CogStash CLI"' not in iss


### PR DESCRIPTION
## Summary
- add a PATH-facing `bin/cogstash.cmd` shim that delegates to `CogStash-CLI.exe`
- stage the shim as part of the Windows installer artifact layout
- update the installer to add `{app}\\bin` to PATH instead of `{app}`
- extend packaging tests to lock the Windows CLI PATH contract

## Verification
- `uv run python -m pytest tests/test_build_installer.py -q`
- `uv run ruff check scripts/_artifacts.py scripts/build_installer.py tests/test_build_installer.py`
- `uv run mypy --explicit-package-bases scripts/_artifacts.py scripts/build_installer.py`

Closes #37