### PR TITLE
fix: harden config loading and markdown export

### DIFF
--- a/src/cogstash/cli/main.py
+++ b/src/cogstash/cli/main.py
@@ -271,17 +271,25 @@ def _write_export_file(out_path: Path, export_format: str, notes: list[Note], to
         else:
             lines = ["# CogStash Export\n\n", f"*Exported {len(notes)} notes on {today}*\n\n"]
             for note in notes:
-                ts = note.timestamp.strftime("%Y-%m-%d %H:%M")
-                tags = " ".join(f"`#{tag}`" for tag in note.tags) if note.tags else ""
-                status = "☑" if note.is_done else ""
-                line = f"- **[{ts}]** {status} {note.text}"
-                if tags:
-                    line += f"  {tags}"
-                lines.append(line + "\n")
+                lines.append(_format_markdown_export_note(note))
             out_path.write_text("".join(lines), encoding="utf-8")
     except OSError:
         safe_print(f"Error: failed to export notes to {out_path}.", file=sys.stderr)
         sys.exit(1)
+
+
+def _format_markdown_export_note(note: Note) -> str:
+    """Render one note as a stable Markdown list item, preserving multiline bodies."""
+    ts = note.timestamp.strftime("%Y-%m-%d %H:%M")
+    tags = " ".join(f"`#{tag}`" for tag in note.tags) if note.tags else ""
+    status = "☑" if note.is_done else ""
+    text_lines = note.text.splitlines() or [""]
+    line = f"- **[{ts}]** {status} {text_lines[0]}"
+    if tags:
+        line += f"  {tags}"
+    rendered_lines = [line.rstrip()]
+    rendered_lines.extend(f"  {continuation}" for continuation in text_lines[1:])
+    return "\n".join(rendered_lines) + "\n"
 
 
 def cmd_export(args, config: CogStashConfig, ansi_tag=None):

--- a/src/cogstash/core/config.py
+++ b/src/cogstash/core/config.py
@@ -52,12 +52,23 @@ def write_json_file(path: Path, data: object) -> None:
     path.write_text(to_pretty_json(data), encoding="utf-8")
 
 
+def _validated_path_value(merged: dict[str, object], *, key: str, default: str) -> Path:
+    """Return a config path field or a safe default when the stored value is invalid."""
+    raw_value = merged.get(key, default)
+    if not isinstance(raw_value, str):
+        logger.warning("Invalid %s value %r — falling back to %s", key, raw_value, default)
+        raw_value = default
+    return Path(raw_value).expanduser()
+
+
 def load_config(config_path: Path) -> CogStashConfig:
     """Load config from JSON file, merging with defaults."""
+    default_output_file = str(Path.home() / "cogstash.md")
+    default_log_file = str(Path.home() / "cogstash.log")
     defaults = {
         "hotkey": _DEFAULT_HOTKEY,
-        "output_file": str(Path.home() / "cogstash.md"),
-        "log_file": str(Path.home() / "cogstash.log"),
+        "output_file": default_output_file,
+        "log_file": default_log_file,
         "theme": _DEFAULT_THEME,
         "window_size": _DEFAULT_WINDOW_SIZE,
         "launch_at_startup": False,
@@ -109,8 +120,8 @@ def load_config(config_path: Path) -> CogStashConfig:
 
     return CogStashConfig(
         hotkey=merged["hotkey"],
-        output_file=Path(merged["output_file"]).expanduser(),
-        log_file=Path(merged["log_file"]).expanduser(),
+        output_file=_validated_path_value(merged, key="output_file", default=default_output_file),
+        log_file=_validated_path_value(merged, key="log_file", default=default_log_file),
         theme=merged["theme"],
         window_size=merged["window_size"],
         tags=valid_tags if valid_tags else None,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -783,6 +783,51 @@ def test_cmd_export_md(tmp_path, monkeypatch, capsys):
     assert "buy milk" in content
 
 
+def test_cmd_export_md_indents_multiline_note_bodies(tmp_path):
+    from types import SimpleNamespace
+
+    from cogstash.cli import cmd_export
+    from cogstash.core import CogStashConfig
+
+    notes_file = tmp_path / "cogstash.md"
+    notes_file.write_text(
+        "- [2026-03-28 09:00] first line #todo\n"
+        "  second line\n"
+        "  third line\n",
+        encoding="utf-8",
+    )
+    out_path = tmp_path / "multiline.md"
+
+    cmd_export(SimpleNamespace(format="md", output=str(out_path)), CogStashConfig(output_file=notes_file))
+
+    content = out_path.read_text(encoding="utf-8")
+    assert "- **[2026-03-28 09:00]**  first line #todo  `#todo`" in content
+    assert "  second line" in content
+    assert "  third line" in content
+
+
+def test_cmd_export_md_keeps_mixed_single_and_multiline_entries_stable(tmp_path):
+    from types import SimpleNamespace
+
+    from cogstash.cli import cmd_export
+    from cogstash.core import CogStashConfig
+
+    notes_file = tmp_path / "cogstash.md"
+    notes_file.write_text(
+        "- [2026-03-28 09:00] single line #idea\n"
+        "- [2026-03-28 10:00] multi start #todo\n"
+        "  multi tail\n",
+        encoding="utf-8",
+    )
+    out_path = tmp_path / "mixed.md"
+
+    cmd_export(SimpleNamespace(format="md", output=str(out_path)), CogStashConfig(output_file=notes_file))
+
+    content = out_path.read_text(encoding="utf-8")
+    assert "- **[2026-03-28 09:00]**  single line #idea  `#idea`" in content
+    assert "- **[2026-03-28 10:00]**  multi start #todo  `#todo`\n  multi tail\n" in content
+
+
 def test_cmd_export_custom_output(tmp_path, capsys):
     """--output flag writes to specified path."""
     import json

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -70,6 +70,47 @@ def test_load_config_unknown_window_size(tmp_path):
     assert config.window_size == "default"
 
 
+def test_load_config_invalid_output_file_type_falls_back_to_default(tmp_path, caplog):
+    from cogstash.core import load_config
+
+    cfg_file = tmp_path / "cogstash.json"
+    cfg_file.write_text(json.dumps({"output_file": []}), encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="cogstash"):
+        config = load_config(cfg_file)
+
+    assert config.output_file == Path.home() / "cogstash.md"
+    assert "Invalid output_file" in caplog.text
+
+
+def test_load_config_invalid_log_file_type_falls_back_to_default(tmp_path, caplog):
+    from cogstash.core import load_config
+
+    cfg_file = tmp_path / "cogstash.json"
+    cfg_file.write_text(json.dumps({"log_file": {"bad": True}}), encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="cogstash"):
+        config = load_config(cfg_file)
+
+    assert config.log_file == Path.home() / "cogstash.log"
+    assert "Invalid log_file" in caplog.text
+
+
+def test_load_config_null_path_values_fall_back_to_defaults(tmp_path, caplog):
+    from cogstash.core import load_config
+
+    cfg_file = tmp_path / "cogstash.json"
+    cfg_file.write_text(json.dumps({"output_file": None, "log_file": None}), encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="cogstash"):
+        config = load_config(cfg_file)
+
+    assert config.output_file == Path.home() / "cogstash.md"
+    assert config.log_file == Path.home() / "cogstash.log"
+    assert "Invalid output_file" in caplog.text
+    assert "Invalid log_file" in caplog.text
+
+
 def test_get_default_config_path_uses_home(monkeypatch, tmp_path):
     import cogstash.core as core_mod
     import cogstash.core.config as config_mod


### PR DESCRIPTION
## Summary
- harden config loading so invalid `output_file` and `log_file` value types fall back safely instead of crashing startup
- preserve multiline note structure in Markdown exports by indenting continuation lines under each list item
- add focused regression tests for config path validation and Markdown export structure

## Notes
- issue #40 is already satisfied on `main`; this PR covers the remaining pending fixes for #39 and #41

## Verification
- `uv run python -m pytest tests/core/test_config.py tests/cli/test_cli.py -k "cmd_export or load_config_invalid or load_config_null" -q`
- `uv run ruff check src/cogstash/core/config.py src/cogstash/cli/main.py tests/core/test_config.py tests/cli/test_cli.py`
- `uv run mypy src/cogstash/core/config.py src/cogstash/cli/main.py`

Closes #39
Closes #41