### PR TITLE
fix: reject non-object config JSON

### DIFF
--- a/src/cogstash/core/config.py
+++ b/src/cogstash/core/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -89,6 +90,10 @@ def load_config(config_path: Path) -> CogStashConfig:
         data = json.loads(config_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as e:
         logger.warning("Bad config file %s: %s — using defaults", config_path, e)
+        return CogStashConfig()
+
+    if not isinstance(data, Mapping):
+        logger.warning("Bad config file %s: top-level JSON value must be an object — using defaults", config_path)
         return CogStashConfig()
 
     merged = {**defaults, **data}

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -111,6 +111,59 @@ def test_load_config_null_path_values_fall_back_to_defaults(tmp_path, caplog):
     assert "Invalid log_file" in caplog.text
 
 
+def test_load_config_non_object_json_list_falls_back_to_defaults(tmp_path, caplog):
+    from cogstash.core import load_config
+
+    cfg_file = tmp_path / "cogstash.json"
+    cfg_file.write_text("[]", encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="cogstash"):
+        config = load_config(cfg_file)
+
+    assert config.theme == "tokyo-night"
+    assert config.output_file == Path.home() / "cogstash.md"
+    assert "top-level JSON value must be an object" in caplog.text
+
+
+def test_load_config_non_object_json_string_falls_back_to_defaults(tmp_path, caplog):
+    from cogstash.core import load_config
+
+    cfg_file = tmp_path / "cogstash.json"
+    cfg_file.write_text('"hello"', encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="cogstash"):
+        config = load_config(cfg_file)
+
+    assert config.theme == "tokyo-night"
+    assert "top-level JSON value must be an object" in caplog.text
+
+
+def test_load_config_non_object_json_number_falls_back_to_defaults(tmp_path, caplog):
+    from cogstash.core import load_config
+
+    cfg_file = tmp_path / "cogstash.json"
+    cfg_file.write_text("42", encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="cogstash"):
+        config = load_config(cfg_file)
+
+    assert config.theme == "tokyo-night"
+    assert "top-level JSON value must be an object" in caplog.text
+
+
+def test_load_config_non_object_json_null_falls_back_to_defaults(tmp_path, caplog):
+    from cogstash.core import load_config
+
+    cfg_file = tmp_path / "cogstash.json"
+    cfg_file.write_text("null", encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="cogstash"):
+        config = load_config(cfg_file)
+
+    assert config.theme == "tokyo-night"
+    assert "top-level JSON value must be an object" in caplog.text
+
+
 def test_get_default_config_path_uses_home(monkeypatch, tmp_path):
     import cogstash.core as core_mod
     import cogstash.core.config as config_mod


### PR DESCRIPTION
## Summary
- reject top-level non-object JSON config payloads before merging with defaults
- fall back to default config values instead of crashing on valid-but-wrong JSON shapes
- add regression coverage for array, string, number, and null config payloads

## Verification
- `uv run python -m pytest tests/core/test_config.py -q`
- `uv run ruff check src/cogstash/core/config.py tests/core/test_config.py`
- `uv run mypy src/cogstash/core/config.py`

Fixes #43