### PR TITLE
fix: validate notes file path in UI flows

### DIFF
--- a/src/cogstash/ui/settings.py
+++ b/src/cogstash/ui/settings.py
@@ -32,6 +32,13 @@ def validate_hotkey(value: str) -> tuple[bool, str | None]:
     return True, None
 
 
+def validate_notes_file_path(value: str) -> tuple[bool, str | None]:
+    """Validate the notes file path entered in settings and onboarding flows."""
+    if not value.strip():
+        return False, "Notes file path is required."
+    return True, None
+
+
 class SettingsWindow:
     """Tab-based settings window accessible from the tray menu."""
 
@@ -241,8 +248,13 @@ class SettingsWindow:
         if not is_valid:
             messagebox.showerror("Invalid Hotkey", error, parent=self.win)
             return
+        notes_path = self.notes_file_var.get()
+        is_valid, error = validate_notes_file_path(notes_path)
+        if not is_valid:
+            messagebox.showerror("Invalid Notes File", error, parent=self.win)
+            return
         self.config.hotkey = hotkey
-        self.config.output_file = Path(self.notes_file_var.get()).expanduser()
+        self.config.output_file = Path(notes_path).expanduser()
         new_launch = self.launch_var.get()
         if new_launch != self.config.launch_at_startup:
             windows_runtime.set_launch_at_startup(new_launch)
@@ -789,8 +801,13 @@ class WizardWindow:
         if not is_valid:
             messagebox.showerror("Invalid Hotkey", error, parent=self.win)
             return
+        notes_path = self.notes_file_var.get()
+        is_valid, error = validate_notes_file_path(notes_path)
+        if not is_valid:
+            messagebox.showerror("Invalid Notes File", error, parent=self.win)
+            return
         self.config.hotkey = hotkey
-        self.config.output_file = Path(self.notes_file_var.get()).expanduser()
+        self.config.output_file = Path(notes_path).expanduser()
         self.config.theme = self.selected_theme.get()
         self.config.window_size = self.selected_size.get()
         self.config.last_seen_version = __version__

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -148,6 +149,25 @@ def test_settings_invalid_hotkey_shows_error_and_does_not_save(tk_root, tmp_path
 
 
 @needs_display
+def test_settings_empty_notes_path_shows_error_and_does_not_save(tk_root, tmp_path):
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.settings import SettingsWindow
+
+    config_path = tmp_path / "test.json"
+    sw = SettingsWindow(tk_root, CogStashConfig(), config_path)
+    sw.notes_file_var.set("")
+
+    with patch("tkinter.messagebox.showerror") as error_mock:
+        sw._save_general()
+
+    assert sw.config.output_file == Path.home() / "cogstash.md"
+    assert not config_path.exists()
+    error_mock.assert_called_once()
+    assert "Notes File" in error_mock.call_args.args[0]
+    sw.win.destroy()
+
+
+@needs_display
 def test_settings_test_hotkey_shows_success_for_valid_input(tk_root, tmp_path, monkeypatch):
     """Test Hotkey should confirm valid hotkey syntax and guidance."""
     from cogstash.ui.app import CogStashConfig
@@ -204,6 +224,26 @@ def test_wizard_finish_persists_edited_hotkey(tk_root, tmp_path):
 
     data = json.loads(config_path.read_text(encoding="utf-8"))
     assert data["hotkey"] == "<ctrl>+<alt>+h"
+    wiz.win.destroy()
+
+
+@needs_display
+def test_wizard_empty_notes_path_shows_error_and_does_not_save(tk_root, tmp_path):
+    from cogstash.ui.app import CogStashConfig
+    from cogstash.ui.settings import WizardWindow
+
+    config = CogStashConfig()
+    config_path = tmp_path / ".cogstash.json"
+    wiz = WizardWindow(tk_root, config, config_path)
+    wiz.notes_file_var.set("")
+
+    with patch("tkinter.messagebox.showerror") as error_mock:
+        wiz._finish()
+
+    assert config.output_file == Path.home() / "cogstash.md"
+    assert not config_path.exists()
+    error_mock.assert_called_once()
+    assert "Notes File" in error_mock.call_args.args[0]
     wiz.win.destroy()
 
 


### PR DESCRIPTION
## Summary
- reject blank notes file paths in the settings window before saving
- reject blank notes file paths in the first-run wizard before finishing
- add regression tests that confirm invalid empty paths show an error and do not persist changes

## Verification
- `uv run python -m pytest tests/ui/test_settings.py -k "empty_notes_path or save_general or wizard_finish" -q`
- `uv run ruff check src/cogstash/ui/settings.py tests/ui/test_settings.py`
- `uv run mypy src/cogstash/ui/settings.py`

Fixes #44