### PR TITLE
refactor: untangle shared UI ownership

### DIFF
--- a/src/cogstash/ui/app.py
+++ b/src/cogstash/ui/app.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import logging
 import queue
-import sys
 import tkinter as tk
 from pathlib import Path
 from tkinter import messagebox
@@ -26,23 +25,9 @@ from cogstash.core import (
 )
 from cogstash.core import parse_smart_tags as _parse_smart_tags
 from cogstash.ui import app_runtime, windows_runtime
+from cogstash.ui.ui_shared import THEMES, WINDOW_SIZES, platform_font
 
 parse_smart_tags = _parse_smart_tags
-
-# ── Data ──────────────────────────────────────────────────────────────────────
-THEMES = {
-    "tokyo-night": {"bg": "#1a1b26", "fg": "#a9b1d6", "entry_bg": "#24283b", "accent": "#7aa2f7", "muted": "#565f89", "error": "#f7768e"},
-    "light":       {"bg": "#faf4ed", "fg": "#575279", "entry_bg": "#f2e9e1", "accent": "#d7827e", "muted": "#9893a5", "error": "#b4637a"},
-    "dracula":     {"bg": "#282a36", "fg": "#f8f8f2", "entry_bg": "#44475a", "accent": "#bd93f9", "muted": "#6272a4", "error": "#ff5555"},
-    "gruvbox":     {"bg": "#282828", "fg": "#ebdbb2", "entry_bg": "#3c3836", "accent": "#b8bb26", "muted": "#665c54", "error": "#fb4934"},
-    "mono":        {"bg": "#0a0a0a", "fg": "#d0d0d0", "entry_bg": "#1a1a1a", "accent": "#d0d0d0", "muted": "#4a4a4a", "error": "#ff3333"},
-}
-
-WINDOW_SIZES = {
-    "compact": {"width": 320, "lines": 2, "max_lines": 5},
-    "default": {"width": 400, "lines": 3, "max_lines": 8},
-    "wide":    {"width": 520, "lines": 4, "max_lines": 10},
-}
 
 # ── Config ────────────────────────────────────────────────────────────────────
 LOG_FILE    = Path.home() / "cogstash.log"
@@ -77,16 +62,6 @@ def _build_hotkey_failure_warning(config: CogStashConfig) -> str:
         f"See the log file for technical details: {config.log_file}\n"
         "If needed, change the hotkey in config for now, then restart CogStash."
     )
-
-
-def platform_font() -> str:
-    """Return the native font family for the current OS."""
-    fonts = {
-        "win32": "Segoe UI",
-        "darwin": "Helvetica Neue",
-        "linux": "sans-serif",
-    }
-    return fonts.get(sys.platform, "TkDefaultFont")
 
 
 def configure_dpi() -> None:

--- a/src/cogstash/ui/browse.py
+++ b/src/cogstash/ui/browse.py
@@ -25,7 +25,7 @@ from cogstash.core import (
     search_notes,
 )
 from cogstash.core.notes import _atomic_write
-from cogstash.ui.app import THEMES, platform_font
+from cogstash.ui.ui_shared import THEMES, platform_font
 
 
 class BrowseWindow:

--- a/src/cogstash/ui/settings.py
+++ b/src/cogstash/ui/settings.py
@@ -10,7 +10,7 @@ from pynput import keyboard
 
 from cogstash.core import DEFAULT_SMART_TAGS, CogStashConfig, merge_tags, save_config
 from cogstash.ui import windows_runtime
-from cogstash.ui.app import (
+from cogstash.ui.ui_shared import (
     THEMES,
     WINDOW_SIZES,
     platform_font,

--- a/src/cogstash/ui/ui_shared.py
+++ b/src/cogstash/ui/ui_shared.py
@@ -1,0 +1,36 @@
+"""Shared UI theme and platform helpers.
+
+These values are consumed by multiple UI modules and intentionally live outside
+the app entrypoint so dialogs and browse views do not depend on ``ui.app``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+THEMES = {
+    "tokyo-night": {"bg": "#1a1b26", "fg": "#a9b1d6", "entry_bg": "#24283b", "accent": "#7aa2f7", "muted": "#565f89", "error": "#f7768e"},
+    "light": {"bg": "#faf4ed", "fg": "#575279", "entry_bg": "#f2e9e1", "accent": "#d7827e", "muted": "#9893a5", "error": "#b4637a"},
+    "dracula": {"bg": "#282a36", "fg": "#f8f8f2", "entry_bg": "#44475a", "accent": "#bd93f9", "muted": "#6272a4", "error": "#ff5555"},
+    "gruvbox": {"bg": "#282828", "fg": "#ebdbb2", "entry_bg": "#3c3836", "accent": "#b8bb26", "muted": "#665c54", "error": "#fb4934"},
+    "mono": {"bg": "#0a0a0a", "fg": "#d0d0d0", "entry_bg": "#1a1a1a", "accent": "#d0d0d0", "muted": "#4a4a4a", "error": "#ff3333"},
+}
+
+WINDOW_SIZES = {
+    "compact": {"width": 320, "lines": 2, "max_lines": 5},
+    "default": {"width": 400, "lines": 3, "max_lines": 8},
+    "wide": {"width": 520, "lines": 4, "max_lines": 10},
+}
+
+
+def platform_font() -> str:
+    """Return the native font family for the current OS."""
+    fonts = {
+        "win32": "Segoe UI",
+        "darwin": "Helvetica Neue",
+        "linux": "sans-serif",
+    }
+    return fonts.get(sys.platform, "TkDefaultFont")
+
+
+__all__ = ["THEMES", "WINDOW_SIZES", "platform_font"]

--- a/tests/ui/test_settings_extended.py
+++ b/tests/ui/test_settings_extended.py
@@ -303,15 +303,26 @@ def test_app_open_settings_uses_shared_config_path(tk_root, tmp_path):
 
 def test_settings_module_imports_core_owned_config_helpers():
     settings_source = Path("src/cogstash/ui/settings.py").read_text(encoding="utf-8")
-    _, ui_app_import_block = settings_source.split("from cogstash.ui.app import (", 1)
-    ui_app_import_block = ui_app_import_block.split(")", 1)[0]
+    _, ui_shared_import_block = settings_source.split("from cogstash.ui.ui_shared import (", 1)
+    ui_shared_import_block = ui_shared_import_block.split(")", 1)[0]
 
     assert "from cogstash.core import " in settings_source
+    assert "from cogstash.ui.app import " not in settings_source
     assert "DEFAULT_SMART_TAGS" in settings_source
     assert "CogStashConfig" in settings_source
     assert "merge_tags" in settings_source
     assert "save_config" in settings_source
-    assert "DEFAULT_SMART_TAGS" not in ui_app_import_block
-    assert "CogStashConfig" not in ui_app_import_block
-    assert "merge_tags" not in ui_app_import_block
-    assert "save_config" not in ui_app_import_block
+    assert "THEMES" in ui_shared_import_block
+    assert "WINDOW_SIZES" in ui_shared_import_block
+    assert "platform_font" in ui_shared_import_block
+    assert "DEFAULT_SMART_TAGS" not in ui_shared_import_block
+    assert "CogStashConfig" not in ui_shared_import_block
+    assert "merge_tags" not in ui_shared_import_block
+    assert "save_config" not in ui_shared_import_block
+
+
+def test_browse_module_imports_shared_ui_contract_not_app():
+    browse_source = Path("src/cogstash/ui/browse.py").read_text(encoding="utf-8")
+
+    assert "from cogstash.ui.ui_shared import THEMES, platform_font" in browse_source
+    assert "from cogstash.ui.app import THEMES, platform_font" not in browse_source


### PR DESCRIPTION
## Summary
- extract shared UI theme presets, window sizes, and platform font selection into `ui_shared`
- rewire app, settings, and browse modules to consume the neutral shared UI contract instead of importing through `ui.app`
- update boundary-focused tests to assert the new import direction

## Verification
- `uv run python -m pytest tests/ui/test_app_compat.py tests/ui/test_settings_extended.py tests/ui/test_browse_extended.py -k "platform_font or theme_colors or window_size_presets or imports_shared_ui_contract or imports_core_owned_config_helpers or avoids_search_wrapper_imports" -q`
- `uv run ruff check src/cogstash/ui/app.py src/cogstash/ui/settings.py src/cogstash/ui/browse.py src/cogstash/ui/ui_shared.py tests/ui/test_settings_extended.py tests/ui/test_app_compat.py tests/ui/test_browse_extended.py`
- `uv run mypy src/cogstash/ui/app.py src/cogstash/ui/settings.py src/cogstash/ui/browse.py src/cogstash/ui/ui_shared.py`

Fixes #45