### PR TITLE
fix: validate startup config booleans

### DIFF
--- a/src/cogstash/core/config.py
+++ b/src/cogstash/core/config.py
@@ -62,6 +62,15 @@ def _validated_path_value(merged: dict[str, object], *, key: str, default: str) 
     return Path(raw_value).expanduser()
 
 
+def _validated_bool_value(merged: dict[str, object], *, key: str, default: bool) -> bool:
+    """Return a config boolean field or a safe default when the stored value is invalid."""
+    raw_value = merged.get(key, default)
+    if not isinstance(raw_value, bool):
+        logger.warning("Invalid %s value %r — falling back to %s", key, raw_value, default)
+        return default
+    return raw_value
+
+
 def load_config(config_path: Path) -> CogStashConfig:
     """Load config from JSON file, merging with defaults."""
     default_output_file = str(Path.home() / "cogstash.md")
@@ -130,7 +139,7 @@ def load_config(config_path: Path) -> CogStashConfig:
         theme=merged["theme"],
         window_size=merged["window_size"],
         tags=valid_tags if valid_tags else None,
-        launch_at_startup=bool(merged.get("launch_at_startup", False)),
+        launch_at_startup=_validated_bool_value(merged, key="launch_at_startup", default=False),
         last_seen_version=str(merged.get("last_seen_version", "")),
         last_seen_installer_version=str(merged.get("last_seen_installer_version", "")),
     )

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -111,6 +111,56 @@ def test_load_config_null_path_values_fall_back_to_defaults(tmp_path, caplog):
     assert "Invalid log_file" in caplog.text
 
 
+def test_load_config_launch_at_startup_true_round_trips(tmp_path):
+    from cogstash.core import load_config
+
+    cfg_file = tmp_path / "cogstash.json"
+    cfg_file.write_text(json.dumps({"launch_at_startup": True}), encoding="utf-8")
+
+    config = load_config(cfg_file)
+
+    assert config.launch_at_startup is True
+
+
+def test_load_config_invalid_launch_at_startup_string_falls_back_to_default(tmp_path, caplog):
+    from cogstash.core import load_config
+
+    cfg_file = tmp_path / "cogstash.json"
+    cfg_file.write_text(json.dumps({"launch_at_startup": "false"}), encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="cogstash"):
+        config = load_config(cfg_file)
+
+    assert config.launch_at_startup is False
+    assert "Invalid launch_at_startup" in caplog.text
+
+
+def test_load_config_invalid_launch_at_startup_object_falls_back_to_default(tmp_path, caplog):
+    from cogstash.core import load_config
+
+    cfg_file = tmp_path / "cogstash.json"
+    cfg_file.write_text(json.dumps({"launch_at_startup": {"bad": True}}), encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="cogstash"):
+        config = load_config(cfg_file)
+
+    assert config.launch_at_startup is False
+    assert "Invalid launch_at_startup" in caplog.text
+
+
+def test_load_config_invalid_launch_at_startup_null_falls_back_to_default(tmp_path, caplog):
+    from cogstash.core import load_config
+
+    cfg_file = tmp_path / "cogstash.json"
+    cfg_file.write_text(json.dumps({"launch_at_startup": None}), encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="cogstash"):
+        config = load_config(cfg_file)
+
+    assert config.launch_at_startup is False
+    assert "Invalid launch_at_startup" in caplog.text
+
+
 def test_load_config_non_object_json_list_falls_back_to_defaults(tmp_path, caplog):
     from cogstash.core import load_config
 


### PR DESCRIPTION
## Summary
- validate `launch_at_startup` strictly as a boolean when loading config
- log and fall back safely when malformed non-boolean values are persisted
- add focused regression tests for string, object, null, and valid boolean inputs

## Verification
- `$env:UV_PROJECT_ENVIRONMENT='.venv-issue51'; uv run python -m pytest tests/core/test_config.py -q`
- `$env:UV_PROJECT_ENVIRONMENT='.venv-issue51'; uv run ruff check src/cogstash/core/config.py tests/core/test_config.py`
- `$env:UV_PROJECT_ENVIRONMENT='.venv-issue51'; uv run mypy src/cogstash/core/config.py`

Fixes #51