### PR TITLE
fix: harden cli config json handling

### DIFF
--- a/src/cogstash/cli/main.py
+++ b/src/cogstash/cli/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
 
@@ -385,19 +386,29 @@ def _get_valid_window_sizes() -> list[str]:
     return sorted(VALID_WINDOW_SIZES)
 
 
-def _config_wizard(config: CogStashConfig, config_path: Path) -> None:
-    """Interactive configuration wizard — walks through all settings."""
+def _load_mutable_config_data(config_path: Path) -> dict[str, object]:
+    """Load writable config JSON, falling back to an empty object on bad shapes."""
     import json as json_mod
 
+    if not config_path.exists():
+        return {}
+
+    try:
+        data = json_mod.loads(config_path.read_text(encoding="utf-8"))
+    except (json_mod.JSONDecodeError, OSError):
+        return {}
+
+    if not isinstance(data, Mapping):
+        return {}
+
+    return dict(data)
+
+
+def _config_wizard(config: CogStashConfig, config_path: Path) -> None:
+    """Interactive configuration wizard — walks through all settings."""
     valid_themes = _get_valid_themes()
     valid_sizes = _get_valid_window_sizes()
-
-    data = {}
-    if config_path.exists():
-        try:
-            data = json_mod.loads(config_path.read_text(encoding="utf-8"))
-        except (json_mod.JSONDecodeError, OSError):
-            data = {}
+    data = _load_mutable_config_data(config_path)
 
     safe_print("⚙️  CogStash Configuration Wizard")
     safe_print("Press Enter to keep current value\n")
@@ -454,8 +465,6 @@ def _config_wizard(config: CogStashConfig, config_path: Path) -> None:
 
 def cmd_config(args, config: CogStashConfig, ansi_tag=None, config_path: Path | None = None):
     """View or modify CogStash configuration."""
-    import json as json_mod
-
     if config_path is None:
         config_path = get_default_config_path()
 
@@ -499,12 +508,7 @@ def cmd_config(args, config: CogStashConfig, ansi_tag=None, config_path: Path | 
         safe_print(f"Error: invalid window_size '{args.value}'. Valid: {', '.join(valid_sizes)}", file=sys.stderr)
         sys.exit(1)
 
-    data = {}
-    if config_path.exists():
-        try:
-            data = json_mod.loads(config_path.read_text(encoding="utf-8"))
-        except (json_mod.JSONDecodeError, OSError):
-            data = {}
+    data = _load_mutable_config_data(config_path)
     data[args.key] = args.value
     write_json_file(config_path, data)
     safe_print(f"{args.key} = {args.value}")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1108,6 +1108,32 @@ def test_cmd_config_set(tmp_path, capsys):
     assert "dracula" in output
 
 
+def test_cmd_config_set_recovers_from_non_object_json(tmp_path, capsys):
+    """config set should recover when the config file contains a non-object JSON value."""
+    import json
+    from types import SimpleNamespace
+
+    from cogstash.cli import cmd_config
+    from cogstash.core import CogStashConfig
+
+    config_path = tmp_path / ".cogstash.json"
+
+    for raw in ("[]", '"hello"', "42", "null"):
+        config_path.write_text(raw, encoding="utf-8")
+
+        cmd_config(
+            SimpleNamespace(action="set", key="theme", value="dracula"),
+            CogStashConfig(theme="tokyo-night"),
+            config_path=config_path,
+        )
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data["theme"] == "dracula"
+
+    output = capsys.readouterr().out
+    assert "theme = dracula" in output
+
+
 def test_cmd_config_set_invalid_theme(tmp_path, capsys):
     """cogstash config set rejects invalid theme."""
     config_path = tmp_path / ".cogstash.json"
@@ -1146,6 +1172,33 @@ def test_cmd_config_wizard(tmp_path, monkeypatch, capsys):
     )
     output = capsys.readouterr().out
     assert "saved" in output.lower() or "Config" in output
+
+
+def test_cmd_config_wizard_recovers_from_non_object_json(tmp_path, monkeypatch, capsys):
+    """config wizard should recover when the config file contains a non-object JSON value."""
+    import json
+    from types import SimpleNamespace
+
+    from cogstash.cli import cmd_config
+    from cogstash.core import CogStashConfig
+
+    config_path = tmp_path / ".cogstash.json"
+
+    for raw in ("[]", '"hello"', "42", "null"):
+        config_path.write_text(raw, encoding="utf-8")
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        cmd_config(
+            SimpleNamespace(action=None, key=None, value=None),
+            CogStashConfig(),
+            config_path=config_path,
+        )
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert isinstance(data, dict)
+
+    output = capsys.readouterr().out
+    assert "saved" in output.lower() or "config" in output.lower()
 
 
 def test_cmd_config_get_invalid_key(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- harden CLI config mutation flows against non-object top-level JSON
- use one shared helper for `config` wizard and `config set`
- add regression coverage for list, string, number, and null config payloads

## Verification
- `uv run python -m pytest tests/cli/test_cli.py -k "cmd_config" -q`
- `uv run ruff check src/cogstash/cli/main.py tests/cli/test_cli.py`
- `uv run mypy src/cogstash/cli/main.py`

Fixes #50