### PR TITLE
fix: close config hardening gaps

### DIFF
--- a/src/cogstash/cli/main.py
+++ b/src/cogstash/cli/main.py
@@ -404,6 +404,14 @@ def _load_mutable_config_data(config_path: Path) -> dict[str, object]:
     return dict(data)
 
 
+def _validate_cli_config_path_value(value: str, *, key: str) -> str | None:
+    """Validate a CLI-supplied config path value, returning an error when invalid."""
+    candidate = Path(value).expanduser()
+    if candidate.exists() and candidate.is_dir():
+        return f"Error: {key} must point to a file, not a directory."
+    return None
+
+
 def _config_wizard(config: CogStashConfig, config_path: Path) -> None:
     """Interactive configuration wizard — walks through all settings."""
     valid_themes = _get_valid_themes()
@@ -441,13 +449,21 @@ def _config_wizard(config: CogStashConfig, config_path: Path) -> None:
     safe_print(f"  Current: {config.output_file}")
     value = input("  New path: ").strip()
     if value:
-        data["output_file"] = value
+        error = _validate_cli_config_path_value(value, key="output_file")
+        if error:
+            safe_print(f"  ⚠ {error[7:]}")
+        else:
+            data["output_file"] = value
 
     safe_print("\n❺ Log File")
     safe_print(f"  Current: {config.log_file}")
     value = input("  New path: ").strip()
     if value:
-        data["log_file"] = value
+        error = _validate_cli_config_path_value(value, key="log_file")
+        if error:
+            safe_print(f"  ⚠ {error[7:]}")
+        else:
+            data["log_file"] = value
 
     safe_print("\n❻ Custom Tags")
     if config.tags:
@@ -507,6 +523,11 @@ def cmd_config(args, config: CogStashConfig, ansi_tag=None, config_path: Path | 
     if args.key == "window_size" and args.value not in valid_sizes:
         safe_print(f"Error: invalid window_size '{args.value}'. Valid: {', '.join(valid_sizes)}", file=sys.stderr)
         sys.exit(1)
+    if args.key in {"output_file", "log_file"}:
+        error = _validate_cli_config_path_value(args.value, key=args.key)
+        if error:
+            safe_print(error, file=sys.stderr)
+            sys.exit(1)
 
     data = _load_mutable_config_data(config_path)
     data[args.key] = args.value

--- a/src/cogstash/core/config.py
+++ b/src/cogstash/core/config.py
@@ -11,9 +11,9 @@ _HEX_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
 _DEFAULT_HOTKEY = "<ctrl>+<shift>+<space>"
 _DEFAULT_THEME = "tokyo-night"
 _DEFAULT_WINDOW_SIZE = "default"
-# Keep this in sync with THEMES in cogstash.ui.app. tests/core/test_config.py guards the key set.
+# Keep this in sync with THEMES in cogstash.ui.ui_shared. tests/core/test_config.py guards the key set.
 VALID_THEMES = {"tokyo-night", "light", "dracula", "gruvbox", "mono"}
-# Keep this in sync with WINDOW_SIZES in cogstash.ui.app. tests/core/test_config.py guards the key set.
+# Keep this in sync with WINDOW_SIZES in cogstash.ui.ui_shared. tests/core/test_config.py guards the key set.
 VALID_WINDOW_SIZES = {"compact", "default", "wide"}
 
 logger = logging.getLogger("cogstash")
@@ -60,6 +60,15 @@ def _validated_path_value(merged: dict[str, object], *, key: str, default: str) 
         logger.warning("Invalid %s value %r — falling back to %s", key, raw_value, default)
         raw_value = default
     return Path(raw_value).expanduser()
+
+
+def _validated_string_value(merged: dict[str, object], *, key: str, default: str) -> str:
+    """Return a config string field or a safe default when the stored value is invalid."""
+    raw_value = merged.get(key, default)
+    if not isinstance(raw_value, str):
+        logger.warning("Invalid %s value %r — falling back to %s", key, raw_value, default)
+        return default
+    return raw_value
 
 
 def _validated_bool_value(merged: dict[str, object], *, key: str, default: bool) -> bool:
@@ -133,7 +142,7 @@ def load_config(config_path: Path) -> CogStashConfig:
             valid_tags[name] = {"emoji": emoji, "color": color}
 
     return CogStashConfig(
-        hotkey=merged["hotkey"],
+        hotkey=_validated_string_value(merged, key="hotkey", default=_DEFAULT_HOTKEY),
         output_file=_validated_path_value(merged, key="output_file", default=default_output_file),
         log_file=_validated_path_value(merged, key="log_file", default=default_log_file),
         theme=merged["theme"],

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1153,6 +1153,58 @@ def test_cmd_config_set_invalid_theme(tmp_path, capsys):
         )
 
 
+def test_cmd_config_set_rejects_directory_output_file(tmp_path, capsys):
+    """config set should reject directory targets for output_file."""
+    import json
+    from types import SimpleNamespace
+
+    import pytest
+
+    from cogstash.cli import cmd_config
+    from cogstash.core import CogStashConfig
+
+    config_path = tmp_path / ".cogstash.json"
+    config_path.write_text("{}", encoding="utf-8")
+    output_dir = tmp_path / "notes-dir"
+    output_dir.mkdir()
+
+    with pytest.raises(SystemExit):
+        cmd_config(
+            SimpleNamespace(action="set", key="output_file", value=str(output_dir)),
+            CogStashConfig(),
+            config_path=config_path,
+        )
+
+    assert json.loads(config_path.read_text(encoding="utf-8")) == {}
+    assert "must point to a file, not a directory" in capsys.readouterr().err
+
+
+def test_cmd_config_set_rejects_directory_log_file(tmp_path, capsys):
+    """config set should reject directory targets for log_file."""
+    import json
+    from types import SimpleNamespace
+
+    import pytest
+
+    from cogstash.cli import cmd_config
+    from cogstash.core import CogStashConfig
+
+    config_path = tmp_path / ".cogstash.json"
+    config_path.write_text("{}", encoding="utf-8")
+    log_dir = tmp_path / "logs-dir"
+    log_dir.mkdir()
+
+    with pytest.raises(SystemExit):
+        cmd_config(
+            SimpleNamespace(action="set", key="log_file", value=str(log_dir)),
+            CogStashConfig(),
+            config_path=config_path,
+        )
+
+    assert json.loads(config_path.read_text(encoding="utf-8")) == {}
+    assert "must point to a file, not a directory" in capsys.readouterr().err
+
+
 def test_cmd_config_wizard(tmp_path, monkeypatch, capsys):
     """Interactive wizard updates config file."""
     config_path = tmp_path / ".cogstash.json"
@@ -1172,6 +1224,60 @@ def test_cmd_config_wizard(tmp_path, monkeypatch, capsys):
     )
     output = capsys.readouterr().out
     assert "saved" in output.lower() or "Config" in output
+
+
+def test_cmd_config_wizard_skips_directory_output_file(tmp_path, monkeypatch, capsys):
+    """config wizard should skip directory targets for output_file instead of saving them."""
+    import json
+    from types import SimpleNamespace
+
+    from cogstash.cli import cmd_config
+    from cogstash.core import CogStashConfig
+
+    config_path = tmp_path / ".cogstash.json"
+    config_path.write_text("{}", encoding="utf-8")
+    output_dir = tmp_path / "notes-dir"
+    output_dir.mkdir()
+
+    responses = iter(["", "", "", str(output_dir), "", ""])
+    monkeypatch.setattr("builtins.input", lambda _: next(responses))
+
+    cmd_config(
+        SimpleNamespace(action=None, key=None, value=None),
+        CogStashConfig(),
+        config_path=config_path,
+    )
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "output_file" not in data
+    assert "must point to a file, not a directory" in capsys.readouterr().out
+
+
+def test_cmd_config_wizard_skips_directory_log_file(tmp_path, monkeypatch, capsys):
+    """config wizard should skip directory targets for log_file instead of saving them."""
+    import json
+    from types import SimpleNamespace
+
+    from cogstash.cli import cmd_config
+    from cogstash.core import CogStashConfig
+
+    config_path = tmp_path / ".cogstash.json"
+    config_path.write_text("{}", encoding="utf-8")
+    log_dir = tmp_path / "logs-dir"
+    log_dir.mkdir()
+
+    responses = iter(["", "", "", "", str(log_dir), ""])
+    monkeypatch.setattr("builtins.input", lambda _: next(responses))
+
+    cmd_config(
+        SimpleNamespace(action=None, key=None, value=None),
+        CogStashConfig(),
+        config_path=config_path,
+    )
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "log_file" not in data
+    assert "must point to a file, not a directory" in capsys.readouterr().out
 
 
 def test_cmd_config_wizard_recovers_from_non_object_json(tmp_path, monkeypatch, capsys):

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -70,6 +70,19 @@ def test_load_config_unknown_window_size(tmp_path):
     assert config.window_size == "default"
 
 
+def test_load_config_invalid_hotkey_type_falls_back_to_default(tmp_path, caplog):
+    from cogstash.core import load_config
+
+    cfg_file = tmp_path / "cogstash.json"
+    cfg_file.write_text(json.dumps({"hotkey": []}), encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="cogstash"):
+        config = load_config(cfg_file)
+
+    assert config.hotkey == "<ctrl>+<shift>+<space>"
+    assert "Invalid hotkey" in caplog.text
+
+
 def test_load_config_invalid_output_file_type_falls_back_to_default(tmp_path, caplog):
     from cogstash.core import load_config
 


### PR DESCRIPTION
## Summary
- validate `hotkey` as a string in the core config loader and fall back safely on malformed values
- reject existing directory targets in CLI config mutation flows for `output_file` and `log_file`
- update stale config ownership comments to point at `ui_shared`
- add focused regression tests for loader-side hotkey validation and CLI path validation

## Verification
- `$env:UV_PROJECT_ENVIRONMENT='.venv-issue55'; uv run python -m pytest tests/core/test_config.py tests/cli/test_cli.py -k "hotkey or launch_at_startup or cmd_config" -q`
- `$env:UV_PROJECT_ENVIRONMENT='.venv-issue55'; uv run ruff check src/cogstash/core/config.py src/cogstash/cli/main.py tests/core/test_config.py tests/cli/test_cli.py`
- `$env:UV_PROJECT_ENVIRONMENT='.venv-issue55'; uv run mypy src/cogstash/core/config.py src/cogstash/cli/main.py`

Fixes #55